### PR TITLE
在Goravle项目中使用队列问题

### DIFF
--- a/app/jobs/test_job.go
+++ b/app/jobs/test_job.go
@@ -1,0 +1,38 @@
+package jobs
+
+import (
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"github.com/goravel/framework/facades"
+)
+
+type TestJob struct {
+}
+
+// Signature The name and signature of the job.
+func (receiver *TestJob) Signature() string {
+	return "test_job"
+}
+
+// Handle Execute the job.
+func (receiver *TestJob) Handle(args ...any) error {
+	var count int = 0
+	for {
+		time.Sleep(2 * time.Second)
+		resp, err := http.Get("https://www.baidu.com/")
+		if err != nil {
+			continue
+		}
+		defer resp.Body.Close()
+		body, _ := ioutil.ReadAll(resp.Body) // 读取响应 body, 返回为 []byte
+		facades.Log().Infof("请求结果:%v\n", string(body))
+		count += 1
+		if count > 10 {
+			break
+		}
+	}
+	facades.Log().Infof("队列退出--end")
+	return nil
+}

--- a/app/providers/queue_service_provider.go
+++ b/app/providers/queue_service_provider.go
@@ -1,6 +1,8 @@
 package providers
 
 import (
+	"goravel/app/jobs"
+
 	"github.com/goravel/framework/contracts/foundation"
 	"github.com/goravel/framework/contracts/queue"
 	"github.com/goravel/framework/facades"
@@ -18,5 +20,8 @@ func (receiver *QueueServiceProvider) Boot(app foundation.Application) {
 }
 
 func (receiver *QueueServiceProvider) Jobs() []queue.Job {
-	return []queue.Job{}
+	return []queue.Job{
+		// 注册队列
+		&jobs.TestJob{},
+	}
 }

--- a/config/database.go
+++ b/config/database.go
@@ -103,7 +103,7 @@ func init() {
 		// such as APC or Memcached.
 		"redis": map[string]any{
 			"default": map[string]any{
-				"host":     config.Env("REDIS_HOST", ""),
+				"host":     config.Env("REDIS_HOST", "127.0.0.1"),
 				"password": config.Env("REDIS_PASSWORD", ""),
 				"port":     config.Env("REDIS_PORT", 6379),
 				"database": config.Env("REDIS_DB", 0),

--- a/config/queue.go
+++ b/config/queue.go
@@ -8,7 +8,7 @@ func init() {
 	config := facades.Config()
 	config.Add("queue", map[string]any{
 		// Default Queue Connection Name
-		"default": config.Env("QUEUE_CONNECTION", "sync"),
+		"default": config.Env("QUEUE_CONNECTION", "redis"),
 
 		// Queue Connections
 		//

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/goravel/framework/contracts/queue"
 	"github.com/goravel/framework/facades"
 
 	"goravel/bootstrap"
@@ -41,6 +42,15 @@ func main() {
 			facades.Log().Errorf("Grpc run error: %v", err)
 		}
 	}()
-
+	go func() {
+		//测试队列
+		queueErr := facades.Queue().Worker(&queue.Args{
+			Queue:      "test_job", //队列名称
+			Concurrent: 4,          //4个并发
+		}).Run()
+		if queueErr != nil {
+			facades.Log().Errorf("Queue run error: %v", queueErr)
+		}
+	}()
 	select {}
 }

--- a/tests/Queque/queue_test.go
+++ b/tests/Queque/queue_test.go
@@ -1,0 +1,37 @@
+package Queque
+
+import (
+	"testing"
+
+	"github.com/goravel/framework/contracts/queue"
+	"github.com/goravel/framework/facades"
+	"github.com/stretchr/testify/suite"
+
+	"goravel/app/jobs"
+	"goravel/tests"
+)
+
+type TestQueueSuite struct {
+	suite.Suite
+	tests.TestCase
+}
+
+func TestTestQueueSuite(t *testing.T) {
+	suite.Run(t, new(TestQueueSuite))
+}
+
+// SetupTest will run before each test in the suite.
+func (s *TestQueueSuite) SetupTest() {
+}
+
+// TearDownTest will run after each test in the suite.
+func (s *TestQueueSuite) TearDownTest() {
+}
+
+func (s *TestQueueSuite) TestIndex() {
+	// 1、config/queue.go 文件中需要指定：QUEUE_CONNECTION=redis
+	// 2、根目录下执行air 启动项目服务
+	// 3、在tests/Queue目录下执行go test -v
+	// 4、查看logs/目录下的日志信息
+	_ = facades.Queue().Job(&jobs.TestJob{}, []queue.Arg{}).OnQueue("test_job").Dispatch()
+}


### PR DESCRIPTION
项目中需要在队列去不断查询第三方接口的状态，但是当我在使用redis作为队列的连接之后就会出现队列中的http请求仅执行几次就出现了无响应的情况，这种问题在同步连接的情况下是正常的
1、config/queue.go 文件中需要指定：QUEUE_CONNECTION=redis
2、根目录下执行air 启动项目服务
3、在tests/Queue目录下执行go test -v
4、查看logs/目录下的日志信息

## 📑 Description

Closes https://github.com/goravel/goravel/issues/?

<!-- Please add Review Ready tag when the PR is good to go -->
<!-- More description can be written after this -->

<!-- Do not remove this line -->
@coderabbitai summary
<!-- Trigger AI description by commenting @coderabbitai summary -->

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
