### PR TITLE
bug: Fallback Route Overrides All Routes in Fiber Driver

### DIFF
--- a/config/http.go
+++ b/config/http.go
@@ -13,7 +13,7 @@ func init() {
 	config := facades.Config()
 	config.Add("http", map[string]any{
 		// HTTP Driver
-		"default": "gin",
+		"default": "fiber",
 		// HTTP Drivers
 		"drivers": map[string]any{
 			"gin": map[string]any{

--- a/routes/web.go
+++ b/routes/web.go
@@ -70,4 +70,11 @@ func Web() {
 			})
 		})
 	})
+
+	facades.Route().Fallback(func(ctx http.Context) http.Response {
+		return ctx.Response().Status(404).Json(http.Json{
+			"code":    404,
+			"message": "Not Found",
+		})
+	})
 }


### PR DESCRIPTION
调整成fiber驱动后测试任何路由都会进入Fallback 参考：https://github.com/goravel/goravel/issues/624

<img width="1307" alt="image" src="https://github.com/user-attachments/assets/c186368b-5704-4dd5-b68e-73bc8af4286f" />

![image](https://github.com/user-attachments/assets/e745215f-6964-4951-af7a-1a98ec1532bf)