### PR TITLE
test: cover gRPC transport credentials surface

### DIFF
--- a/tests/feature/grpc_test.go
+++ b/tests/feature/grpc_test.go
@@ -2,7 +2,9 @@ package feature
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"sync"
@@ -10,11 +12,16 @@ import (
 
 	proto "github.com/goravel/example-proto"
 	"github.com/stretchr/testify/suite"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/protobuf/encoding/protojson"
+	protobufproto "google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/protoadapt"
 
 	"goravel/app/facades"
 	"goravel/tests"
+
+	"github.com/goravel/framework/support/color"
 )
 
 type GrpcFeatureSuite struct {
@@ -156,4 +163,116 @@ func (s *GrpcFeatureSuite) TestUserClientConnectionIsCached() {
 	body, err := resp.Body()
 	s.Require().NoError(err)
 	s.Equal(`{"id":1,"name":"Goravel","token":"cached"}`, body)
+}
+
+// TestGrpcCredentials exercises the client side of the gRPC transport
+// credentials surface documented at goravel/docs#192 — specifically the
+// `grpc.servers.<name>.credentials` config key and the fallback semantics
+// that `WithGrpcClientCredentials` enables. The server-side
+// `WithGrpcServerCredentials` path is not covered here because the running
+// app's gRPC server is frozen by the time the suite runs (routes/grpc.go
+// calls facades.Grpc().Server() to bind the UserService, which seeds the
+// server singleton, and the framework has no path to reset the frozen
+// server); a separate goravel/framework change would be needed to make
+// that case testable from the example repo. All cases use the running
+// insecure server on 127.0.0.1:3002, so they exercise the real
+// resolveClientCredentials resolver rather than a stub.
+func (s *GrpcFeatureSuite) TestGrpcCredentials() {
+	s.Run("falls back to insecure when no credentials key set", func() {
+		// Server entry without a `credentials` field.
+		// resolveClientCredentials must return insecure.NewCredentials()
+		// to preserve the v1.17 contract for apps that have not opted
+		// into TLS. Pointing at the already-running insecure server on
+		// 3002 keeps the test focused on the credentials resolver rather
+		// than the TLS handshake.
+		facades.Config().Add("grpc.servers.user-insecure-fallback", map[string]any{
+			"host":           "127.0.0.1",
+			"port":           "3002",
+			"interceptors":   []string{},
+			"stats_handlers": []string{},
+		})
+
+		conn, err := facades.Grpc().Connect("user-insecure-fallback")
+		s.Require().NoError(err)
+		s.NotNil(conn)
+		defer func() { _ = conn.Close() }()
+
+		client := proto.NewUserServiceClient(conn)
+		resp, err := client.GetUser(context.Background(), &proto.UserRequest{Token: "insecure-fallback"})
+		s.Require().NoError(err)
+		s.NotNil(resp)
+
+		s.True(protobufproto.Equal(
+			protoadapt.MessageV2Of(&proto.UserResponse{
+				Code: int32(http.StatusOK),
+				Data: &proto.User{Id: 1, Name: "Goravel", Token: "insecure-fallback"},
+			}),
+			protoadapt.MessageV2Of(resp),
+		), "insecure-fallback response did not match expected UserResponse")
+	})
+
+	s.Run("warns and falls back when credentials group is unknown", func() {
+		// Register a group, but configure a different name so the lookup
+		// misses. The framework should log the warning and fall back to
+		// insecure. ServerName: "noop" makes the registered creds useless
+		// on purpose — we never want the client to actually use them here.
+		facades.Grpc().ClientCredentials(map[string]credentials.TransportCredentials{
+			"tls-unknown": credentials.NewTLS(&tls.Config{ServerName: "noop"}),
+		})
+
+		facades.Config().Add("grpc.servers.user-tls-unknown", map[string]any{
+			"host":           "127.0.0.1",
+			"port":           "3002",
+			"credentials":    "does-not-exist",
+			"interceptors":   []string{},
+			"stats_handlers": []string{},
+		})
+
+		var (
+			conn *grpc.ClientConn
+			cErr error
+		)
+		got := color.CaptureOutput(func(io.Writer) {
+			conn, cErr = facades.Grpc().Connect("user-tls-unknown")
+		})
+		s.Require().NoError(cErr)
+		s.NotNil(conn)
+		defer func() { _ = conn.Close() }()
+
+		s.Contains(got, `client credentials group "does-not-exist" is not registered for server "user-tls-unknown"`)
+		s.Contains(got, "falling back to insecure credentials")
+	})
+
+	s.Run("returns insecure silently when groups registered but config key empty", func() {
+		// Groups are registered for "tls-empty" but the server entry omits
+		// the credentials key entirely. resolveClientCredentials must take
+		// the silent-insecure path (no warning), distinct from the
+		// "unknown group" path above.
+		facades.Grpc().ClientCredentials(map[string]credentials.TransportCredentials{
+			"tls-empty": credentials.NewTLS(&tls.Config{ServerName: "noop"}),
+		})
+
+		facades.Config().Add("grpc.servers.user-tls-empty", map[string]any{
+			"host":           "127.0.0.1",
+			"port":           "3002",
+			"interceptors":   []string{},
+			"stats_handlers": []string{},
+		})
+
+		var (
+			conn *grpc.ClientConn
+			cErr error
+		)
+		got := color.CaptureOutput(func(io.Writer) {
+			conn, cErr = facades.Grpc().Connect("user-tls-empty")
+		})
+		s.Require().NoError(cErr)
+		s.NotNil(conn)
+		defer func() { _ = conn.Close() }()
+
+		// Empty key is the documented "no creds wanted" path; the
+		// framework only warns when a key was provided but unmatched.
+		s.NotContains(got, "falling back to insecure credentials")
+		s.NotContains(got, "is not registered for server")
+	})
 }


### PR DESCRIPTION
## Summary
- Add test coverage for the client side of the gRPC transport credentials surface introduced in docs#192: `WithGrpcClientCredentials` and the per-server `grpc.servers.<name>.credentials` config key
- Cover the three documented fallback paths on the client: insecure when no key is set, warn-and-fall-back when the key references an unknown group, and silent insecure when groups are registered but the key is empty

## Why
The gRPC credentials surface added in `goravel/framework` has no integration coverage in the example app today — the bootstrap is unchanged and the documented `WithGrpcClientCredentials` resolver paths are unverified. This PR adds end-to-end coverage driven from `facades.Grpc()`, so each case exercises the real `resolveClientCredentials` resolver rather than a unit-level stub.

The server side (`WithGrpcServerCredentials`) is deliberately not covered. The running app's gRPC server is frozen by the time the suite runs: `routes/grpc.go` calls `facades.Grpc().Server()` to register the UserService, which seeds the server singleton, and after that `ServerCredentials` is silently dropped. I traced through every framework entry point I could find (`foundation.NewApplication`, `foundation.Setup().Create`, `app.Boot`) — each one either skips the gRPC service provider, or runs the artisan/runner pipeline that races the test by auto-starting the server on the configured port. None of them give a clean "fresh gRPC app for testing" path. Covering the server side would need a separate `goravel/framework` change to expose a server-reset hook; the test code and comment point at this so the next reader does not have to retrace the same path. The three cases below run against the singleton's running insecure server on 127.0.0.1:3002:

```go
// bootstrap/app.go
import "google.golang.org/grpc/credentials"

func Boot() foundation.Application {
    return foundation.Setup().
        WithGrpcClientCredentials(func() map[string]credentials.TransportCredentials {
            userCreds, err := credentials.NewClientTLSFromFile("storage/certs/ca.crt", "user.example.com")
            if err != nil {
                panic(err)
            }
            return map[string]credentials.TransportCredentials{"user": userCreds}
        }).
        Create()
}
```

The unknown-group case calls `color.CaptureOutput` and asserts the warning contains both `client credentials group "does-not-exist" is not registered for server ...` and `falling back to insecure credentials` — the exact text the framework prints, so a future change to that wording will surface in the diff.
