### PR TITLE
feat: add WithCommandsFilter example (#126)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ func TestFunction(t *testing.T) {
 
 ### Telemetry feature tests
 
-- Use the `tests/telemetry` kit: `EnsureStack` for compose services, `AwaitTraces`/`AwaitMetric`/`AwaitLogs` for backend assertions, `OverrideConfig`/`Restore` for config changes, `GenerateCollectorCerts` for TLS material.
+- Use the `tests/telemetry` kit: `EnsureStack` for compose services, `AwaitTraces`/`AwaitMetric`/`AwaitLogs` for backend assertions, `GenerateCollectorCerts` for TLS material. Use `tests.OverrideConfig`/`Restore` for config changes.
 - Never `time.Sleep` in telemetry suites; readiness and export latency are handled by the kit.
-- Every suite must claim a unique `telemetry.service.name` via `OverrideConfig` and query by it; backends stay warm and accumulate data across suites.
+- Every suite must claim a unique `telemetry.service.name` via `tests.OverrideConfig` and query by it; backends stay warm and accumulate data across suites.
 - Suites never run `docker compose down`; teardown is owned by `TestMain` via `telemetry.TeardownStack`.

--- a/bootstrap/app.go
+++ b/bootstrap/app.go
@@ -47,6 +47,7 @@ func Boot() contractsfoundation.Application {
 			}
 		}).
 		WithCommands(Commands).
+		WithCommandsFilter(CommandsFilter).
 		WithJobs(Jobs).
 		WithFilters(Filters).
 		WithRules(Rules).

--- a/bootstrap/commands_filter.go
+++ b/bootstrap/commands_filter.go
@@ -1,0 +1,16 @@
+package bootstrap
+
+import "goravel/app/facades"
+
+func CommandsFilter() []string {
+	if facades.Config().GetString("app.env") == "production" {
+		return []string{
+			"up",
+			"down",
+			"make:*",
+			"vendor:publish",
+		}
+	}
+
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/goravel/cos v1.17.0
 	github.com/goravel/example-proto v0.0.1
 	github.com/goravel/fiber v1.17.1-0.20260613035455-658a0afce584
-	github.com/goravel/framework v1.17.2-0.20260620003653-d44f2c8574f2
+	github.com/goravel/framework v1.17.2-0.20260620053855-2059fd0b42f5
 	github.com/goravel/gemini v0.0.0-20260612100742-b6ec562a886a
 	github.com/goravel/gin v1.17.1-0.20260613040118-01d8b930d8e9
 	github.com/goravel/minio v1.17.0
@@ -260,4 +260,4 @@ require (
 	gorm.io/plugin/dbresolver v1.6.2 // indirect
 )
 
-replace github.com/goravel/framework => github.com/goravel/framework v1.17.2-0.20260620003653-d44f2c8574f2
+replace github.com/goravel/framework => github.com/goravel/framework v1.17.2-0.20260620053855-2059fd0b42f5

--- a/go.sum
+++ b/go.sum
@@ -334,8 +334,8 @@ github.com/goravel/example-proto v0.0.1 h1:ZxETeKREQWjuJ49bX/Hqj1NLR5Vyj489Ks6dR
 github.com/goravel/example-proto v0.0.1/go.mod h1:I8IPsHr4Ndf7KxmdsRpBR2LQ0Geo48+pjv9IIWf3mZg=
 github.com/goravel/fiber v1.17.1-0.20260613035455-658a0afce584 h1:RWXKifN0yUIrR4fmD41AAT6Ia5RyBKKf3eI35EvqPWA=
 github.com/goravel/fiber v1.17.1-0.20260613035455-658a0afce584/go.mod h1:HKCvR+HEvQEgDljGoVuwjCUA+iZH0esm5IGDPiUrOdE=
-github.com/goravel/framework v1.17.2-0.20260620003653-d44f2c8574f2 h1:ocjXH8rvX7h/QULAgay4P5qLw8MYbYvTYqq3yIlWHRw=
-github.com/goravel/framework v1.17.2-0.20260620003653-d44f2c8574f2/go.mod h1:J3xvbbFAbS/sYePrlIMfUD6anGcrnE49mnntYlKUvls=
+github.com/goravel/framework v1.17.2-0.20260620053855-2059fd0b42f5 h1:AdhIQXp2HkT99uaz1Jr50xPpWdZogjx/kqWHYVm3W8U=
+github.com/goravel/framework v1.17.2-0.20260620053855-2059fd0b42f5/go.mod h1:J3xvbbFAbS/sYePrlIMfUD6anGcrnE49mnntYlKUvls=
 github.com/goravel/gemini v0.0.0-20260612100742-b6ec562a886a h1:pAqOmhOtpvhZr3jHxv6/cJFEr1gxvM50oQwir35dl+o=
 github.com/goravel/gemini v0.0.0-20260612100742-b6ec562a886a/go.mod h1:9X0bxFWH75aBewyk49An8mmSSp5HOLGGgH9wk0wNgpc=
 github.com/goravel/gin v1.17.1-0.20260613040118-01d8b930d8e9 h1:As8ANVdkEVmgLj+5FrnKCDM96WsxhyMer7y94C17Rfk=

--- a/tests/feature/console_test.go
+++ b/tests/feature/console_test.go
@@ -4,10 +4,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/goravel/framework/support/file"
+	"github.com/goravel/framework/support/path"
 	"github.com/stretchr/testify/suite"
 
 	"goravel/app/console/commands"
 	"goravel/app/facades"
+	"goravel/bootstrap"
 	"goravel/tests"
 )
 
@@ -147,4 +150,18 @@ func (s *ConsoleTestSuite) TestRunShutdownable() {
 	s.NoError(err)
 	s.True(commands.GetShutdownableHandleRan(), "Handle should run")
 	s.True(commands.GetShutdownableShutdownRan(), "Shutdown should run after Handle returns (framework master application.go:209-217)")
+}
+
+func (s *ConsoleTestSuite) TestCommandsFilterReturnsNilInLocalEnv() {
+	filter := bootstrap.CommandsFilter()
+	s.Nil(filter, "CommandsFilter should return nil (keep all) when app.env is not production")
+}
+
+func (s *ConsoleTestSuite) TestCommandsFilterKeepsBuiltInCommands() {
+	s.NoError(facades.Artisan().Call("about"))
+}
+
+func (s *ConsoleTestSuite) TestCommandsFilterKeepsGlobMatchesInLocalEnv() {
+	s.NoError(facades.Artisan().Call("make:command TestGlobFilterCmd"))
+	s.True(file.Contains(path.Bootstrap("commands.go"), "&commands.TestGlobFilterCmd{},"))
 }

--- a/tests/feature/console_test.go
+++ b/tests/feature/console_test.go
@@ -12,7 +12,6 @@ import (
 	"goravel/app/facades"
 	"goravel/bootstrap"
 	"goravel/tests"
-	"goravel/tests/telemetry"
 )
 
 type ConsoleTestSuite struct {
@@ -168,7 +167,7 @@ func (s *ConsoleTestSuite) TestCommandsFilterKeepsGlobMatchesInLocalEnv() {
 }
 
 func (s *ConsoleTestSuite) TestCommandsFilterInProductionEnv() {
-	scope, err := telemetry.OverrideConfig(map[string]any{
+	scope, err := tests.OverrideConfig(map[string]any{
 		"app.env": "production",
 	})
 	s.Require().NoError(err)
@@ -181,4 +180,8 @@ func (s *ConsoleTestSuite) TestCommandsFilterInProductionEnv() {
 	s.Equal([]string{"up", "down", "make:*", "vendor:publish"}, filter)
 
 	s.NoError(facades.Artisan().Call("up"), "up should survive production filter")
+
+	output, err := s.CaptureArtisanOutput("test:console-single")
+	s.NoError(err)
+	s.Contains(output, "Command 'test:console-single' is not defined.", "test:console-single should be excluded in production")
 }

--- a/tests/feature/console_test.go
+++ b/tests/feature/console_test.go
@@ -12,6 +12,7 @@ import (
 	"goravel/app/facades"
 	"goravel/bootstrap"
 	"goravel/tests"
+	"goravel/tests/telemetry"
 )
 
 type ConsoleTestSuite struct {
@@ -164,4 +165,20 @@ func (s *ConsoleTestSuite) TestCommandsFilterKeepsBuiltInCommands() {
 func (s *ConsoleTestSuite) TestCommandsFilterKeepsGlobMatchesInLocalEnv() {
 	s.NoError(facades.Artisan().Call("make:command TestGlobFilterCmd"))
 	s.True(file.Contains(path.Bootstrap("commands.go"), "&commands.TestGlobFilterCmd{},"))
+}
+
+func (s *ConsoleTestSuite) TestCommandsFilterInProductionEnv() {
+	scope, err := telemetry.OverrideConfig(map[string]any{
+		"app.env": "production",
+	})
+	s.Require().NoError(err)
+	defer func() {
+		s.NoError(scope.Restore())
+	}()
+
+	filter := bootstrap.CommandsFilter()
+	s.NotNil(filter, "CommandsFilter should return non-nil in production")
+	s.Equal([]string{"up", "down", "make:*", "vendor:publish"}, filter)
+
+	s.NoError(facades.Artisan().Call("up"), "up should survive production filter")
 }

--- a/tests/feature/telemetry_test.go
+++ b/tests/feature/telemetry_test.go
@@ -25,7 +25,7 @@ func TestTelemetryTestSuite(t *testing.T) {
 func (s *TelemetryTestSuite) SetupSuite() {
 	telemetry.EnsureStack(s.T(), telemetry.ServiceJaeger, telemetry.ServicePrometheus, telemetry.ServiceLoki, telemetry.ServiceCollector)
 
-	scope, err := telemetry.OverrideConfig(map[string]any{
+	scope, err := tests.OverrideConfig(map[string]any{
 		"telemetry.service.name": plainServiceName,
 	})
 	// Cleanup instead of TearDownSuite: it restores the config even when a

--- a/tests/feature/telemetry_tls_test.go
+++ b/tests/feature/telemetry_tls_test.go
@@ -48,7 +48,7 @@ func (s *TelemetryTLSTestSuite) SetupSuite() {
 		overrides[prefix+".tls.ca"] = caPath
 	}
 
-	scope, err := telemetry.OverrideConfig(overrides)
+	scope, err := tests.OverrideConfig(overrides)
 	// Cleanup instead of TearDownSuite: it restores the config even when a
 	// later assertion in SetupSuite fails.
 	s.T().Cleanup(func() {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1,4 +1,4 @@
-package telemetry
+package tests
 
 import (
 	"github.com/goravel/framework/facades"


### PR DESCRIPTION
## Summary
- Add `WithCommandsFilter` builder example to scope registered Artisan commands by environment
- Add integration tests verifying filter returns nil in local env and built-in commands survive
- Add production env test using config override + `Restart()` to verify filter activation

## Why
This adds an example demonstrating the `WithCommandsFilter` builder method introduced in goravel/framework#1500. The filter callback returns a positive list of command signatures to keep in production (using exact and glob matching), and returns nil to keep all commands in dev/local environments.

```go
func CommandsFilter() []string {
	if facades.Config().GetString("app.env") == "production" {
		return []string{
			"up",
			"down",
			"make:*",
			"vendor:publish",
		}
	}

	return nil
}
```

The filter is wired into the builder chain in `bootstrap/app.go`:

```go
return foundation.Setup().
	// ...
	WithCommands(Commands).
	WithCommandsFilter(CommandsFilter).
	// ...
```
