### PR TITLE
test: add validation lang:publish and translation message tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/goravel/cos v1.17.0
 	github.com/goravel/example-proto v0.0.1
 	github.com/goravel/fiber v1.17.1-0.20260621025423-854fc97c753e
-	github.com/goravel/framework v1.17.2-0.20260620111819-895a1923bd91
+	github.com/goravel/framework v1.17.2-0.20260621022129-9ffa3e9c7e45
 	github.com/goravel/gemini v0.0.0-20260612100742-b6ec562a886a
 	github.com/goravel/gin v1.17.1-0.20260620131757-00c7714a6c89
 	github.com/goravel/minio v1.17.0
@@ -258,4 +258,4 @@ require (
 	gorm.io/plugin/dbresolver v1.6.2 // indirect
 )
 
-replace github.com/goravel/framework => github.com/goravel/framework v1.17.2-0.20260620111819-895a1923bd91
+replace github.com/goravel/framework => github.com/goravel/framework v1.17.2-0.20260621022129-9ffa3e9c7e45

--- a/go.sum
+++ b/go.sum
@@ -330,8 +330,8 @@ github.com/goravel/example-proto v0.0.1 h1:ZxETeKREQWjuJ49bX/Hqj1NLR5Vyj489Ks6dR
 github.com/goravel/example-proto v0.0.1/go.mod h1:I8IPsHr4Ndf7KxmdsRpBR2LQ0Geo48+pjv9IIWf3mZg=
 github.com/goravel/fiber v1.17.1-0.20260621025423-854fc97c753e h1:s/ix3p+CZOmVSKr+nNep33n8jte9njW1bhIOWwCjedw=
 github.com/goravel/fiber v1.17.1-0.20260621025423-854fc97c753e/go.mod h1:ah3zvGM3b3oDINo1uvCSpbVZp3OgF2NqL3gC1HF4QvU=
-github.com/goravel/framework v1.17.2-0.20260620111819-895a1923bd91 h1:FvQKsBtW8Cp8OqTTxdPg8EA6geZxA3ScszGxCmLx1l4=
-github.com/goravel/framework v1.17.2-0.20260620111819-895a1923bd91/go.mod h1:J3xvbbFAbS/sYePrlIMfUD6anGcrnE49mnntYlKUvls=
+github.com/goravel/framework v1.17.2-0.20260621022129-9ffa3e9c7e45 h1:CDS4mjStqORdI9hYIihOPMzzvp0WSs5iKD254C/vwDo=
+github.com/goravel/framework v1.17.2-0.20260621022129-9ffa3e9c7e45/go.mod h1:J3xvbbFAbS/sYePrlIMfUD6anGcrnE49mnntYlKUvls=
 github.com/goravel/gemini v0.0.0-20260612100742-b6ec562a886a h1:pAqOmhOtpvhZr3jHxv6/cJFEr1gxvM50oQwir35dl+o=
 github.com/goravel/gemini v0.0.0-20260612100742-b6ec562a886a/go.mod h1:9X0bxFWH75aBewyk49An8mmSSp5HOLGGgH9wk0wNgpc=
 github.com/goravel/gin v1.17.1-0.20260620131757-00c7714a6c89 h1:WwV0hP93UPtC8ZPwH6RNzjFo32t6xNjuKpusH/3xYqU=

--- a/tests/feature/validation_lang_test.go
+++ b/tests/feature/validation_lang_test.go
@@ -1,0 +1,172 @@
+package feature
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/goravel/framework/support/file"
+	"github.com/stretchr/testify/suite"
+
+	"goravel/app/facades"
+	"goravel/tests"
+)
+
+type ValidationLangTestSuite struct {
+	suite.Suite
+	tests.TestCase
+
+	langPath string
+}
+
+func TestValidationLangTestSuite(t *testing.T) {
+	suite.Run(t, &ValidationLangTestSuite{})
+}
+
+func (s *ValidationLangTestSuite) SetupTest() {
+	s.langPath = facades.App().LangPath()
+	s.removeValidationLangFiles()
+}
+
+func (s *ValidationLangTestSuite) TearDownTest() {
+	s.removeValidationLangFiles()
+}
+
+func (s *ValidationLangTestSuite) removeValidationLangFiles() {
+	for _, locale := range []string{"en", "cn"} {
+		_ = os.Remove(filepath.Join(s.langPath, locale, "validation.json"))
+	}
+}
+
+func (s *ValidationLangTestSuite) TestDefaultMessagesWithoutPublishing() {
+	validator, err := facades.Validation().Make(context.Background(),
+		map[string]any{"name": ""},
+		map[string]any{"name": "required"},
+	)
+	s.Require().NoError(err)
+	s.True(validator.Fails())
+	s.Equal("The name field is required.", validator.Errors().One("name"))
+}
+
+func (s *ValidationLangTestSuite) TestLangPublishCommand() {
+	output, err := s.CaptureArtisanOutput("lang:publish")
+	s.Require().NoError(err)
+	s.Contains(output, "Publishing complete")
+
+	targetFile := filepath.Join(s.langPath, "en", "validation.json")
+	s.True(file.Exists(targetFile))
+
+	content, err := os.ReadFile(targetFile)
+	s.Require().NoError(err)
+	s.Contains(string(content), `"required"`)
+	s.Contains(string(content), `"email"`)
+}
+
+func (s *ValidationLangTestSuite) TestLangPublishForce() {
+	s.Require().NoError(facades.Artisan().Call("lang:publish"))
+
+	targetFile := filepath.Join(s.langPath, "en", "validation.json")
+	s.Require().True(file.Exists(targetFile))
+
+	output, err := s.CaptureArtisanOutput("lang:publish")
+	s.Require().NoError(err)
+	s.Contains(output, "Publishing complete")
+
+	s.Require().NoError(facades.Artisan().Call("lang:publish --force"))
+}
+
+func (s *ValidationLangTestSuite) TestOverridePublishedMessages() {
+	s.Require().NoError(facades.Artisan().Call("lang:publish"))
+
+	s.setValidationMessage("en", "required", "Custom required message for :attribute.")
+
+	validator, err := facades.Validation().Make(context.Background(),
+		map[string]any{"name": ""},
+		map[string]any{"name": "required"},
+	)
+	s.Require().NoError(err)
+	s.True(validator.Fails())
+	s.Equal("Custom required message for name.", validator.Errors().One("name"))
+}
+
+func (s *ValidationLangTestSuite) TestNonOverriddenMessagesUseDefaults() {
+	s.Require().NoError(facades.Artisan().Call("lang:publish"))
+
+	s.setValidationMessage("en", "required", "Custom required message for :attribute.")
+
+	validator, err := facades.Validation().Make(context.Background(),
+		map[string]any{"email": "not-an-email"},
+		map[string]any{"email": "email"},
+	)
+	s.Require().NoError(err)
+	s.True(validator.Fails())
+	s.Equal("The email field must be a valid email address.", validator.Errors().One("email"))
+}
+
+func (s *ValidationLangTestSuite) TestLanguageSwitch() {
+	s.Require().NoError(facades.Artisan().Call("lang:publish"))
+
+	validationFile := filepath.Join(s.langPath, "en", "validation.json")
+	content, err := os.ReadFile(validationFile)
+	s.Require().NoError(err)
+
+	var messages map[string]any
+	s.Require().NoError(json.Unmarshal(content, &messages))
+	messages["required"] = "Chinese: The :attribute field is required."
+	messages["email"] = "Chinese: The :attribute field must be a valid email address."
+
+	cnData, err := json.MarshalIndent(messages, "", "  ")
+	s.Require().NoError(err)
+
+	cnDir := filepath.Join(s.langPath, "cn")
+	s.Require().NoError(os.MkdirAll(cnDir, 0o755))
+	s.Require().NoError(os.WriteFile(filepath.Join(cnDir, "validation.json"), cnData, 0o644))
+
+	scope, err := tests.OverrideConfig(map[string]any{
+		"app.locale": "cn",
+	})
+	s.Require().NoError(err)
+	defer func() { s.NoError(scope.Restore()) }()
+
+	validator, err := facades.Validation().Make(context.Background(),
+		map[string]any{"name": ""},
+		map[string]any{"name": "required"},
+	)
+	s.Require().NoError(err)
+	s.True(validator.Fails())
+	s.Equal("Chinese: The name field is required.", validator.Errors().One("name"))
+}
+
+func (s *ValidationLangTestSuite) TestFallbackLocale() {
+	s.Require().NoError(facades.Artisan().Call("lang:publish"))
+
+	scope, err := tests.OverrideConfig(map[string]any{
+		"app.locale": "jp",
+	})
+	s.Require().NoError(err)
+	defer func() { s.NoError(scope.Restore()) }()
+
+	validator, err := facades.Validation().Make(context.Background(),
+		map[string]any{"name": ""},
+		map[string]any{"name": "required"},
+	)
+	s.Require().NoError(err)
+	s.True(validator.Fails())
+	s.Equal("The name field is required.", validator.Errors().One("name"))
+}
+
+func (s *ValidationLangTestSuite) setValidationMessage(locale, rule, message string) {
+	validationFile := filepath.Join(s.langPath, locale, "validation.json")
+	content, err := os.ReadFile(validationFile)
+	s.Require().NoError(err)
+
+	var messages map[string]any
+	s.Require().NoError(json.Unmarshal(content, &messages))
+	messages[rule] = message
+
+	modified, err := json.MarshalIndent(messages, "", "  ")
+	s.Require().NoError(err)
+	s.Require().NoError(os.WriteFile(validationFile, modified, 0o644))
+}

--- a/tests/feature/validation_lang_test.go
+++ b/tests/feature/validation_lang_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	_ "unsafe"
 
 	"github.com/goravel/framework/support/file"
 	"github.com/stretchr/testify/suite"
@@ -13,6 +14,9 @@ import (
 	"goravel/app/facades"
 	"goravel/tests"
 )
+
+//go:linkname translationLoaded github.com/goravel/framework/translation.loaded
+var translationLoaded map[string]map[string]map[string]any
 
 type ValidationLangTestSuite struct {
 	suite.Suite
@@ -32,6 +36,7 @@ func (s *ValidationLangTestSuite) SetupTest() {
 
 func (s *ValidationLangTestSuite) TearDownTest() {
 	s.removeValidationLangFiles()
+	translationLoaded = make(map[string]map[string]map[string]any)
 }
 
 func (s *ValidationLangTestSuite) removeValidationLangFiles() {

--- a/tests/feature/validation_lang_test.go
+++ b/tests/feature/validation_lang_test.go
@@ -16,6 +16,13 @@ import (
 )
 
 //go:linkname translationLoaded github.com/goravel/framework/translation.loaded
+//
+// The translation package caches loaded lang messages in a package-level
+// `loaded` map that never expires. When lang:publish populates this cache
+// with custom messages during TestValidationLangTestSuite, those messages
+// leak into TestValidationTestSuite (which runs next alphabetically),
+// causing default-message assertions to fail. Resetting the map here forces
+// the translator to reload from the embedded defaults fresh after each test.
 var translationLoaded map[string]map[string]map[string]any
 
 type ValidationLangTestSuite struct {


### PR DESCRIPTION
## Summary
- Add `lang:publish` command test coverage for validation language files
- Verify embedded default messages work before publishing
- Test custom message override, language switching, and fallback locale behavior

## Why
[framework#1436](https://github.com/goravel/framework/pull/1436) introduced translation-based validation error messages with embedded `lang/en/validation.json`. [framework#1503](https://github.com/goravel/framework/pull/1503) added the `lang:publish` artisan command to publish these language files to the application.

This adds integration test coverage for both features:

```go
// Publish validation language files
go run . artisan lang:publish

// Customize a message in lang/en/validation.json
// {"required": "Custom required message for :attribute."}

// Validate — the custom message takes precedence over the embedded default
validator, _ := facades.Validation().Make(ctx,
    map[string]any{"name": ""},
    map[string]any{"name": "required"},
)
// validator.Errors().One("name") → "Custom required message for name."
```
