### PR TITLE
feat: add automatic database span coverage to telemetry example

### DIFF
--- a/app/http/controllers/telemetry_controller.go
+++ b/app/http/controllers/telemetry_controller.go
@@ -37,6 +37,19 @@ func (r *TelemetryController) Index(ctx http.Context) http.Response {
 
 	facades.Log().Channel("otel").WithContext(ctx).Info("test telemetry log")
 
+	// Database queries are instrumented automatically. This builder query emits a
+	// "SELECT users" client span nested under the request span with no manual
+	// tracing; facades.Orm() is instrumented the same way.
+	var users []struct {
+		ID   uint   `db:"id"`
+		Name string `db:"name"`
+	}
+	if err := facades.DB().WithContext(ctx).Table("users").Limit(1).Get(&users); err != nil {
+		return ctx.Response().Json(http.StatusInternalServerError, http.Json{
+			"error": err.Error(),
+		})
+	}
+
 	resp, err := facades.Http().WithContext(ctx).Get("/grpc/user?token=1")
 	if err != nil {
 		return ctx.Response().Json(http.StatusInternalServerError, http.Json{

--- a/config/grpc.go
+++ b/config/grpc.go
@@ -13,8 +13,8 @@ func init() {
 		// Configure your server port
 		"port": config.Env("GRPC_PORT"),
 
-		// Configure clients which the framework will connect to
-		"clients": map[string]any{
+		// Configure servers which the client will connect to
+		"servers": map[string]any{
 			"user": map[string]any{
 				"host": config.Env("GRPC_USER_HOST"),
 				"port": config.Env("GRPC_USER_PORT"),

--- a/config/grpc.go
+++ b/config/grpc.go
@@ -13,8 +13,8 @@ func init() {
 		// Configure your server port
 		"port": config.Env("GRPC_PORT"),
 
-		// Configure servers which the client will connect to
-		"servers": map[string]any{
+		// Configure clients which the framework will connect to
+		"clients": map[string]any{
 			"user": map[string]any{
 				"host": config.Env("GRPC_USER_HOST"),
 				"port": config.Env("GRPC_USER_PORT"),

--- a/tests/feature/telemetry_test.go
+++ b/tests/feature/telemetry_test.go
@@ -3,8 +3,10 @@ package feature
 import (
 	"testing"
 
+	"github.com/goravel/framework/contracts/binding"
 	"github.com/stretchr/testify/suite"
 
+	"goravel/app/facades"
 	"goravel/tests"
 	"goravel/tests/telemetry"
 )
@@ -35,6 +37,16 @@ func (s *TelemetryTestSuite) SetupSuite() {
 	})
 	s.Require().NoError(err)
 
+	// The /telemetry handler runs an automatically instrumented DB query. The DB
+	// connection and its bound tracer are cached process-wide and may have been
+	// built by an earlier suite under a different service name. Orm().Fresh()
+	// clears the connection cache, and App().Fresh(binding.DB) drops the already
+	// resolved DB facade so the next query rebuilds the instrument under
+	// plainServiceName. Then recreate the users table the query reads.
+	facades.Orm().Fresh()
+	facades.App().Fresh(binding.DB)
+	s.RefreshDatabase()
+
 	resp, err := s.Http(s.T()).Get("/telemetry")
 	s.Require().NoError(err)
 	resp.AssertSuccessful()
@@ -49,7 +61,7 @@ func (s *TelemetryTestSuite) SetupSuite() {
 func (s *TelemetryTestSuite) TestTraces() {
 	telemetry.AwaitTraces(s.T(), plainServiceName,
 		"GET /telemetry", "HTTP GET", "user.UserService/GetUser", "GET /grpc/user",
-		"users.process", "users.consume")
+		"users.process", "users.consume", "SELECT users")
 }
 
 func (s *TelemetryTestSuite) TestMetrics() {

--- a/tests/feature/telemetry_test.go
+++ b/tests/feature/telemetry_test.go
@@ -3,10 +3,8 @@ package feature
 import (
 	"testing"
 
-	"github.com/goravel/framework/contracts/binding"
 	"github.com/stretchr/testify/suite"
 
-	"goravel/app/facades"
 	"goravel/tests"
 	"goravel/tests/telemetry"
 )
@@ -37,15 +35,8 @@ func (s *TelemetryTestSuite) SetupSuite() {
 	})
 	s.Require().NoError(err)
 
-	// The /telemetry handler runs an automatically instrumented DB query. The DB
-	// connection and its bound tracer are cached process-wide and survive
-	// App().Restart(), so a connection an earlier suite built keeps that suite's
-	// service name. Orm().Fresh() clears the connection cache and
-	// App().Fresh(binding.DB) drops the resolved DB facade, so the next query
-	// rebuilds the instrument under plainServiceName. Then recreate the users
-	// table the query reads.
-	facades.Orm().Fresh()
-	facades.App().Fresh(binding.DB)
+	// The /telemetry handler runs an automatically instrumented DB query, so the
+	// users table must exist for the "SELECT users" span to be produced.
 	s.RefreshDatabase()
 
 	resp, err := s.Http(s.T()).Get("/telemetry")

--- a/tests/feature/telemetry_test.go
+++ b/tests/feature/telemetry_test.go
@@ -38,11 +38,12 @@ func (s *TelemetryTestSuite) SetupSuite() {
 	s.Require().NoError(err)
 
 	// The /telemetry handler runs an automatically instrumented DB query. The DB
-	// connection and its bound tracer are cached process-wide and may have been
-	// built by an earlier suite under a different service name. Orm().Fresh()
-	// clears the connection cache, and App().Fresh(binding.DB) drops the already
-	// resolved DB facade so the next query rebuilds the instrument under
-	// plainServiceName. Then recreate the users table the query reads.
+	// connection and its bound tracer are cached process-wide and survive
+	// App().Restart(), so a connection an earlier suite built keeps that suite's
+	// service name. Orm().Fresh() clears the connection cache and
+	// App().Fresh(binding.DB) drops the resolved DB facade, so the next query
+	// rebuilds the instrument under plainServiceName. Then recreate the users
+	// table the query reads.
 	facades.Orm().Fresh()
 	facades.App().Fresh(binding.DB)
 	s.RefreshDatabase()

--- a/tests/feature/telemetry_tls_test.go
+++ b/tests/feature/telemetry_tls_test.go
@@ -56,6 +56,10 @@ func (s *TelemetryTLSTestSuite) SetupSuite() {
 	})
 	s.Require().NoError(err)
 
+	// The /telemetry handler runs an automatically instrumented DB query, so the
+	// users table must exist for the request to succeed.
+	s.RefreshDatabase()
+
 	resp, err := s.Http(s.T()).Get("/telemetry")
 	s.Require().NoError(err)
 	resp.AssertSuccessful()


### PR DESCRIPTION
## 📑 Description

RelatedTo https://github.com/goravel/goravel/issues/726

Framework #1477 added automatic database instrumentation for both `facades.Orm()` and `facades.DB()`. The framework module has no SQLite driver, so a live database span can only be asserted end to end here, against a real database and the collector stack.

**What is changing:**

* The `/telemetry` handler now runs an automatically instrumented builder query (`facades.DB().WithContext(ctx).Table("users").Limit(1).Get(...)`). No manual tracing: the query emits a `SELECT users` client span nested under the request span, the same way `facades.Orm()` does.
* `TestTraces` asserts the `SELECT users` span alongside the existing HTTP, gRPC, manual, and consume spans.

**Example:**

```go
var users []struct {
    ID   uint   `db:"id"`
    Name string `db:"name"`
}
facades.DB().WithContext(ctx).Table("users").Limit(1).Get(&users)
```

**Depends on goravel/framework#1509:**

The DB connection (and the tracer bound to it) is cached process-wide. The telemetry suite swaps `telemetry.service.name` via `OverrideConfig`, which restarts the app, so the connection must be rebuilt under the new service for the span to report correctly. goravel/framework#1509 makes `app.Restart()` reset database connections, so this suite needs no manual `Orm().Fresh()` / `App().Fresh(binding.DB)` workaround. CI here stays red until that framework PR merges into master.

## ✅ Checks

- [x] Added test cases for my code
