### PR TITLE
test: validate provider routes survive engine rebuild with global middleware

### DIFF
--- a/bootstrap/provider_route.go
+++ b/bootstrap/provider_route.go
@@ -1,0 +1,27 @@
+package bootstrap
+
+import (
+	"github.com/goravel/framework/contracts/binding"
+	"github.com/goravel/framework/contracts/foundation"
+	"github.com/goravel/framework/contracts/http"
+
+	"goravel/app/facades"
+)
+
+type RouteProvider struct{}
+
+func (r *RouteProvider) Relationship() binding.Relationship {
+	return binding.Relationship{
+		Bindings:     []string{},
+		Dependencies: []string{},
+		ProvideFor:   []string{},
+	}
+}
+
+func (r *RouteProvider) Register(app foundation.Application) {}
+
+func (r *RouteProvider) Boot(app foundation.Application) {
+	facades.Route().Get("/provider-route", func(ctx http.Context) http.Response {
+		return ctx.Response().Success().String("Hello from provider route")
+	})
+}

--- a/bootstrap/providers.go
+++ b/bootstrap/providers.go
@@ -80,5 +80,6 @@ func Providers() []foundation.ServiceProvider {
 		&anthropic.ServiceProvider{},
 		&gemini.ServiceProvider{},
 		&viewtest.ServiceProvider{},
+		&RouteProvider{},
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/goravel/cos v1.17.0
 	github.com/goravel/example-proto v0.0.1
 	github.com/goravel/fiber v1.17.1-0.20260627025643-b0f12c46dcc3
-	github.com/goravel/framework v1.17.2-0.20260627030239-d174ca3d4965
+	github.com/goravel/framework v1.17.2-0.20260627035548-8c6802e27755
 	github.com/goravel/gemini v0.0.0-20260612100742-b6ec562a886a
 	github.com/goravel/gin v1.17.1-0.20260627033833-3bbdffa3f231
 	github.com/goravel/minio v1.17.0
@@ -258,4 +258,4 @@ require (
 	gorm.io/plugin/dbresolver v1.6.2 // indirect
 )
 
-replace github.com/goravel/framework => github.com/goravel/framework v1.17.2-0.20260627030239-d174ca3d4965
+replace github.com/goravel/framework => github.com/goravel/framework v1.17.2-0.20260627035548-8c6802e27755

--- a/go.sum
+++ b/go.sum
@@ -330,8 +330,8 @@ github.com/goravel/example-proto v0.0.1 h1:ZxETeKREQWjuJ49bX/Hqj1NLR5Vyj489Ks6dR
 github.com/goravel/example-proto v0.0.1/go.mod h1:I8IPsHr4Ndf7KxmdsRpBR2LQ0Geo48+pjv9IIWf3mZg=
 github.com/goravel/fiber v1.17.1-0.20260627025643-b0f12c46dcc3 h1:HGcFngcJlLFFTlQ8mRBFmgHT6a7n4VrcvZcHGnRq1qA=
 github.com/goravel/fiber v1.17.1-0.20260627025643-b0f12c46dcc3/go.mod h1:tzzGXTgMCHefaQaa3b0GVabonDQkiKmege7VtVHc7RQ=
-github.com/goravel/framework v1.17.2-0.20260627030239-d174ca3d4965 h1:C34nrsU1n7cGnp6gAyXB9UmRJbDN83+e3QlHkUvn4Xc=
-github.com/goravel/framework v1.17.2-0.20260627030239-d174ca3d4965/go.mod h1:P+VHYPXl+gYyzdUixJCIujFNEmsK5IveNSLoFeY4uqo=
+github.com/goravel/framework v1.17.2-0.20260627035548-8c6802e27755 h1:KmmVPbPCD8iAcC3NKKvdlGf0LvhAKAdeG0DYjIHm/1U=
+github.com/goravel/framework v1.17.2-0.20260627035548-8c6802e27755/go.mod h1:P+VHYPXl+gYyzdUixJCIujFNEmsK5IveNSLoFeY4uqo=
 github.com/goravel/gemini v0.0.0-20260612100742-b6ec562a886a h1:pAqOmhOtpvhZr3jHxv6/cJFEr1gxvM50oQwir35dl+o=
 github.com/goravel/gemini v0.0.0-20260612100742-b6ec562a886a/go.mod h1:9X0bxFWH75aBewyk49An8mmSSp5HOLGGgH9wk0wNgpc=
 github.com/goravel/gin v1.17.1-0.20260627033833-3bbdffa3f231 h1:cz984YXT8XCc+auCTo1U2HO67tc9AHTIC+7kVmM9aIY=

--- a/tests/feature/http_test.go
+++ b/tests/feature/http_test.go
@@ -379,3 +379,13 @@ func (s *HttpTestSuite) TestView() {
 	s.NotEmpty(csrfToken)
 	s.Equal(context, fmt.Sprintf("\n  \n<html>\n  <body>\n    <p>I'm the header</p>\n\n  <p>Hello, Goravel</p>\n  <p> CSRF Token: %s </p>\n  \n  <p>I'm the footer</p>\n  </body>\n</html>\n\n", csrfToken))
 }
+
+func (s *HttpTestSuite) TestProviderRoute() {
+	resp, err := s.Http(s.T()).Get("/provider-route")
+	s.NoError(err)
+	resp.AssertSuccessful()
+
+	content, err := resp.Content()
+	s.NoError(err)
+	s.Equal("Hello from provider route", content)
+}


### PR DESCRIPTION
## Summary
- Routes registered in a ServiceProvider's `Boot()` were silently lost when the application had global middleware configured
- Add `RouteProvider` that registers `GET /provider-route` in `Boot()` and a test verifying it responds correctly
- Bump framework to `8c6802e` to pick up the fix from goravel/framework#1508

## Why

[goravel/framework#1508](https://github.com/goravel/framework/pull/1508) fixed a bug where `configureMiddleware` ran after `Boot()`, causing `SetGlobalMiddleware` to rebuild the route engine and silently discard routes registered by service providers during boot. The fix reorders `configureMiddleware` to run between `Register()` and `Boot()`, so the engine is set up with global middleware before providers register their routes.

The example repo had no coverage for this ordering — a provider that registers routes in `Boot()` would have returned 404 without the fix. The new `RouteProvider` and test ensure this contract is preserved.

```go
// bootstrap/provider_route.go — registers a route during Boot()
type RouteProvider struct{}

func (r *RouteProvider) Boot(app foundation.Application) {
	facades.Route().Get("/provider-route", func(ctx http.Context) http.Response {
		return ctx.Response().Success().String("Hello from provider route")
	})
}
```

```go
// tests/feature/http_test.go — validates the route survives
func (s *HttpTestSuite) TestProviderRoute() {
	resp, err := s.Http(s.T()).Get("/provider-route")
	s.NoError(err)
	resp.AssertSuccessful()

	content, err := resp.Content()
	s.NoError(err)
	s.Equal("Hello from provider route", content)
}
```
