### PR TITLE
test: add per-event retry/backoff examples for framework#1529

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 storage
 tmp
 tests/testdata/otel-tls/
+.opencode

--- a/app/events/broadcast.go
+++ b/app/events/broadcast.go
@@ -99,6 +99,13 @@ type TeamPresenceBroadcast struct {
 	TeamData           map[string]any
 	ChannelName        string
 	ShouldBroadcastNow bool
+	QueueName          string
+	Conns              []string
+	QueueConn          string
+	DelayedAt          time.Time
+	Timeout            time.Duration
+	Tries              int
+	Backoff            []time.Duration
 }
 
 func (e *TeamPresenceBroadcast) BroadcastOn() []contracts.Channel {
@@ -121,4 +128,32 @@ func (e *TeamPresenceBroadcast) BroadcastWhen() bool {
 
 func (e *TeamPresenceBroadcast) BroadcastNow() bool {
 	return e.ShouldBroadcastNow
+}
+
+func (e *TeamPresenceBroadcast) BroadcastQueue() string {
+	return e.QueueName
+}
+
+func (e *TeamPresenceBroadcast) BroadcastConnections() []string {
+	return e.Conns
+}
+
+func (e *TeamPresenceBroadcast) BroadcastQueueConnection() string {
+	return e.QueueConn
+}
+
+func (e *TeamPresenceBroadcast) BroadcastDelay() time.Time {
+	return e.DelayedAt
+}
+
+func (e *TeamPresenceBroadcast) BroadcastTimeout() time.Duration {
+	return e.Timeout
+}
+
+func (e *TeamPresenceBroadcast) BroadcastTries() int {
+	return e.Tries
+}
+
+func (e *TeamPresenceBroadcast) BroadcastBackoff() []time.Duration {
+	return e.Backoff
 }

--- a/app/events/broadcast.go
+++ b/app/events/broadcast.go
@@ -15,6 +15,8 @@ type OrderShippedBroadcast struct {
 	QueueConn          string
 	DelayedAt          time.Time
 	Timeout            time.Duration
+	Tries              int
+	Backoff            []time.Duration
 	ShouldBroadcastNow bool
 	ChannelType        string
 	ChannelName        string
@@ -61,6 +63,14 @@ func (e *OrderShippedBroadcast) BroadcastDelay() time.Time {
 
 func (e *OrderShippedBroadcast) BroadcastTimeout() time.Duration {
 	return e.Timeout
+}
+
+func (e *OrderShippedBroadcast) BroadcastTries() int {
+	return e.Tries
+}
+
+func (e *OrderShippedBroadcast) BroadcastBackoff() []time.Duration {
+	return e.Backoff
 }
 
 func (e *OrderShippedBroadcast) BroadcastNow() bool {

--- a/app/events/broadcast.go
+++ b/app/events/broadcast.go
@@ -96,8 +96,9 @@ func (e *EmptyBroadcastEvent) BroadcastWhen() bool {
 }
 
 type TeamPresenceBroadcast struct {
-	TeamData    map[string]any
-	ChannelName string
+	TeamData           map[string]any
+	ChannelName        string
+	ShouldBroadcastNow bool
 }
 
 func (e *TeamPresenceBroadcast) BroadcastOn() []contracts.Channel {
@@ -116,4 +117,8 @@ func (e *TeamPresenceBroadcast) BroadcastWith() map[string]any {
 
 func (e *TeamPresenceBroadcast) BroadcastWhen() bool {
 	return true
+}
+
+func (e *TeamPresenceBroadcast) BroadcastNow() bool {
+	return e.ShouldBroadcastNow
 }

--- a/app/http/controllers/broadcast_controller.go
+++ b/app/http/controllers/broadcast_controller.go
@@ -63,6 +63,18 @@ func stripPresencePrefix(name string) string {
 	return strings.TrimPrefix(name, "presence-")
 }
 
+// queueOptions converts the request's delay/backoff/timeout (seconds) into the
+// queue-option values forwarded to broadcast events.
+func queueOptions(req *DispatchRequest) (delayedAt time.Time, timeout time.Duration, tries int, backoff []time.Duration) {
+	if req.Delay > 0 {
+		delayedAt = time.Now().UTC().Add(time.Duration(req.Delay) * time.Second)
+	}
+	for _, b := range req.Backoff {
+		backoff = append(backoff, time.Duration(b*float64(time.Second)))
+	}
+	return delayedAt, time.Duration(req.Timeout) * time.Second, req.Tries, backoff
+}
+
 func (c *BroadcastController) dispatchPrivate(ctx http.Context, req *DispatchRequest) http.Response {
 	if req.ShouldFire && req.OrderData == nil {
 		req.OrderData = map[string]any{
@@ -70,15 +82,7 @@ func (c *BroadcastController) dispatchPrivate(ctx http.Context, req *DispatchReq
 			"price": 1200,
 		}
 	}
-	var delayedAt time.Time
-	if req.Delay > 0 {
-		delayedAt = time.Now().UTC().Add(time.Duration(req.Delay) * time.Second)
-	}
-
-	var backoff []time.Duration
-	for _, b := range req.Backoff {
-		backoff = append(backoff, time.Duration(b*float64(time.Second)))
-	}
+	delayedAt, timeout, tries, backoff := queueOptions(req)
 
 	err := facades.Broadcast().Dispatch(context.Background(), &events.OrderShippedBroadcast{
 		OrderData:          req.OrderData,
@@ -87,8 +91,8 @@ func (c *BroadcastController) dispatchPrivate(ctx http.Context, req *DispatchReq
 		Conns:              req.Conns,
 		QueueConn:          req.QueueConn,
 		DelayedAt:          delayedAt,
-		Timeout:            time.Duration(req.Timeout) * time.Second,
-		Tries:              req.Tries,
+		Timeout:            timeout,
+		Tries:              tries,
 		Backoff:            backoff,
 		ShouldBroadcastNow: req.BroadcastNow,
 		ChannelName:        stripPrivatePrefix(req.Channel),
@@ -109,10 +113,19 @@ func (c *BroadcastController) dispatchPublic(ctx http.Context, req *DispatchRequ
 			"price": 1200,
 		}
 	}
+	delayedAt, timeout, tries, backoff := queueOptions(req)
+
 	err := facades.Broadcast().Dispatch(context.Background(), &events.OrderShippedBroadcast{
 		ChannelType:        "public",
 		OrderData:          req.OrderData,
-		ShouldFire:         true,
+		ShouldFire:         req.ShouldFire,
+		QueueName:          req.QueueName,
+		Conns:              req.Conns,
+		QueueConn:          req.QueueConn,
+		DelayedAt:          delayedAt,
+		Timeout:            timeout,
+		Tries:              tries,
+		Backoff:            backoff,
 		ShouldBroadcastNow: req.BroadcastNow,
 		ChannelName:        req.Channel,
 	})
@@ -131,10 +144,19 @@ func (c *BroadcastController) dispatchPresence(ctx http.Context, req *DispatchRe
 			"name": "goravel",
 		}
 	}
+	delayedAt, timeout, tries, backoff := queueOptions(req)
+
 	err := facades.Broadcast().Dispatch(context.Background(), &events.TeamPresenceBroadcast{
 		TeamData:           req.TeamData,
 		ChannelName:        stripPresencePrefix(req.Channel),
 		ShouldBroadcastNow: req.BroadcastNow,
+		QueueName:          req.QueueName,
+		Conns:              req.Conns,
+		QueueConn:          req.QueueConn,
+		DelayedAt:          delayedAt,
+		Timeout:            timeout,
+		Tries:              tries,
+		Backoff:            backoff,
 	})
 	if err != nil {
 		return ctx.Response().Json(http.StatusInternalServerError, http.Json{"error": err.Error()})

--- a/app/http/controllers/broadcast_controller.go
+++ b/app/http/controllers/broadcast_controller.go
@@ -132,8 +132,9 @@ func (c *BroadcastController) dispatchPresence(ctx http.Context, req *DispatchRe
 		}
 	}
 	err := facades.Broadcast().Dispatch(context.Background(), &events.TeamPresenceBroadcast{
-		TeamData:    req.TeamData,
-		ChannelName: stripPresencePrefix(req.Channel),
+		TeamData:           req.TeamData,
+		ChannelName:        stripPresencePrefix(req.Channel),
+		ShouldBroadcastNow: req.BroadcastNow,
 	})
 	if err != nil {
 		return ctx.Response().Json(http.StatusInternalServerError, http.Json{"error": err.Error()})

--- a/app/http/controllers/broadcast_controller.go
+++ b/app/http/controllers/broadcast_controller.go
@@ -28,6 +28,8 @@ type DispatchRequest struct {
 	Conns        []string       `form:"conns" json:"conns"`
 	Delay        int64          `form:"delay" json:"delay"`
 	Timeout      int64          `form:"timeout" json:"timeout"`
+	Tries        int            `form:"tries" json:"tries"`
+	Backoff      []float64      `form:"backoff" json:"backoff"` // seconds per attempt, fractional allowed, e.g. [0.5,1]
 	BroadcastNow bool           `form:"broadcast_now" json:"broadcast_now"`
 }
 
@@ -73,6 +75,11 @@ func (c *BroadcastController) dispatchPrivate(ctx http.Context, req *DispatchReq
 		delayedAt = time.Now().UTC().Add(time.Duration(req.Delay) * time.Second)
 	}
 
+	var backoff []time.Duration
+	for _, b := range req.Backoff {
+		backoff = append(backoff, time.Duration(b*float64(time.Second)))
+	}
+
 	err := facades.Broadcast().Dispatch(context.Background(), &events.OrderShippedBroadcast{
 		OrderData:          req.OrderData,
 		ShouldFire:         req.ShouldFire,
@@ -81,6 +88,8 @@ func (c *BroadcastController) dispatchPrivate(ctx http.Context, req *DispatchReq
 		QueueConn:          req.QueueConn,
 		DelayedAt:          delayedAt,
 		Timeout:            time.Duration(req.Timeout) * time.Second,
+		Tries:              req.Tries,
+		Backoff:            backoff,
 		ShouldBroadcastNow: req.BroadcastNow,
 		ChannelName:        stripPrivatePrefix(req.Channel),
 	})

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/goravel/cos v1.18.0
 	github.com/goravel/example-proto v0.0.1
 	github.com/goravel/fiber v1.18.0
-	github.com/goravel/framework v1.18.1-0.20260731090025-d8687160f9d4
+	github.com/goravel/framework v1.18.1-0.20260802085640-2aa82fd133a7
 	github.com/goravel/gemini v1.18.0
 	github.com/goravel/gin v1.18.0
 	github.com/goravel/minio v1.18.0
@@ -32,7 +32,7 @@ require (
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/metric v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
-	google.golang.org/grpc v1.82.0
+	google.golang.org/grpc v1.82.1
 	google.golang.org/protobuf v1.36.11
 )
 
@@ -96,7 +96,7 @@ require (
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
-	github.com/gabriel-vasile/mimetype v1.4.13 // indirect
+	github.com/gabriel-vasile/mimetype v1.4.15 // indirect
 	github.com/gin-contrib/sse v1.1.0 // indirect
 	github.com/gin-contrib/timeout v1.2.1 // indirect
 	github.com/gin-gonic/gin v1.12.0 // indirect
@@ -152,7 +152,7 @@ require (
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.22 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
-	github.com/mattn/go-runewidth v0.0.24 // indirect
+	github.com/mattn/go-runewidth v0.0.27 // indirect
 	github.com/microsoft/go-mssqldb v1.9.1 // indirect
 	github.com/minio/crc64nvme v1.1.1 // indirect
 	github.com/minio/md5-simd v1.1.2 // indirect
@@ -236,7 +236,7 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/arch v0.22.0 // indirect
 	golang.org/x/crypto v0.54.0 // indirect
-	golang.org/x/exp v0.0.0-20260709172345-9ea1abe57597 // indirect
+	golang.org/x/exp v0.0.0-20260718201538-764159d718ef // indirect
 	golang.org/x/mod v0.38.0 // indirect
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
@@ -257,4 +257,4 @@ require (
 	gorm.io/plugin/dbresolver v1.6.2 // indirect
 )
 
-replace github.com/goravel/framework => github.com/goravel/framework v1.18.1-0.20260731090025-d8687160f9d4
+replace github.com/goravel/framework => github.com/goravel/framework v1.18.1-0.20260802085640-2aa82fd133a7

--- a/go.sum
+++ b/go.sum
@@ -212,8 +212,8 @@ github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fxamacker/cbor/v2 v2.9.2 h1:X4Ksno9+x3cz0TZv69ec1hxP/+tymuR8PXQJyDwfh78=
 github.com/fxamacker/cbor/v2 v2.9.2/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/gabriel-vasile/mimetype v1.4.13 h1:46nXokslUBsAJE/wMsp5gtO500a4F3Nkz9Ufpk2AcUM=
-github.com/gabriel-vasile/mimetype v1.4.13/go.mod h1:d+9Oxyo1wTzWdyVUPMmXFvp4F9tea18J8ufA774AB3s=
+github.com/gabriel-vasile/mimetype v1.4.15 h1:05iP/CYtZ/w455R/KZM6rZ5ieAdh99UPtd+d3YzLmaI=
+github.com/gabriel-vasile/mimetype v1.4.15/go.mod h1:azpTcoLcDZRNgFou5j+APrqQx9HqVPWa6ijYQIIVswQ=
 github.com/gin-contrib/sse v1.1.0 h1:n0w2GMuUpWDVp7qSpvze6fAu9iRxJY4Hmj6AmBOU05w=
 github.com/gin-contrib/sse v1.1.0/go.mod h1:hxRZ5gVpWMT7Z0B0gSNYqqsSCNIJMjzvm6fqCz9vjwM=
 github.com/gin-contrib/timeout v1.2.1 h1:vw+1K+rDo1M86G00A1RdQZDP9JJDcJjYj6+9ZVowjlk=
@@ -324,8 +324,8 @@ github.com/goravel/example-proto v0.0.1 h1:ZxETeKREQWjuJ49bX/Hqj1NLR5Vyj489Ks6dR
 github.com/goravel/example-proto v0.0.1/go.mod h1:I8IPsHr4Ndf7KxmdsRpBR2LQ0Geo48+pjv9IIWf3mZg=
 github.com/goravel/fiber v1.18.0 h1:q9EACPCpEn+N5SX6yyI7hsdA1Zr2NFDJLdiAXQKKUw8=
 github.com/goravel/fiber v1.18.0/go.mod h1:swGaS9bq2wT6T6uthcHEJ2In6QyaTljsqrkRwk+wPfI=
-github.com/goravel/framework v1.18.1-0.20260731090025-d8687160f9d4 h1:5yTlZ1L6uJsMY9BwvH9IHW5Q2oZcrfhNCXCIaadJjuE=
-github.com/goravel/framework v1.18.1-0.20260731090025-d8687160f9d4/go.mod h1:xmT+tLgweQXZoFqnDWE7YYgxMxhs3x72e5m6PHfW9S4=
+github.com/goravel/framework v1.18.1-0.20260802085640-2aa82fd133a7 h1:RrMz33q2XLIy9v7Ib7GPUgPnqOT6yzLiN0GV4FtXcKk=
+github.com/goravel/framework v1.18.1-0.20260802085640-2aa82fd133a7/go.mod h1:fyN4D/EeI2qxGsXBJpsKLBGf67bXMyvYrU/uUdhsLqc=
 github.com/goravel/gemini v1.18.0 h1:Tv6IJ3KvBvH5QD7kAM3XFQR0g8IUfkqMbRGi7dtlWUo=
 github.com/goravel/gemini v1.18.0/go.mod h1:b4FueB0O0Qkz71eVWLiSaKghp+Eb/1hNNICkk7vMgrQ=
 github.com/goravel/gin v1.18.0 h1:4eIy9eAzH+0mz8SN03iwwocIGwc/2dpZkgz6Ol68KIE=
@@ -426,8 +426,8 @@ github.com/mattn/go-isatty v0.0.22/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJ
 github.com/mattn/go-localereader v0.0.1 h1:ygSAOl7ZXTx4RdPYinUpg6W99U8jWvWi9Ye2JC/oIi4=
 github.com/mattn/go-localereader v0.0.1/go.mod h1:8fBrzywKY7BI3czFoHkuzRoWE9C+EiG4R1k4Cjx5p88=
 github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
-github.com/mattn/go-runewidth v0.0.24 h1:cpokDiIn0MGnhdHwuWnJBITySJ20QyNGnY2kR/ay2DU=
-github.com/mattn/go-runewidth v0.0.24/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
+github.com/mattn/go-runewidth v0.0.27 h1:Feg/Oou5zI/wnpgDF6omIU0OokC9GxLC/WRknhVlIR0=
+github.com/mattn/go-runewidth v0.0.27/go.mod h1:3qAiGCV4Koz/yuveO58qUefmUTRm8r0IGEXZ9jeHp/8=
 github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
 github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/microsoft/go-mssqldb v1.8.2/go.mod h1:vp38dT33FGfVotRiTmDo3bFyaHq+p3LektQrjTULowo=
@@ -706,8 +706,8 @@ golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL
 golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20191030013958-a1ab85dbe136/go.mod h1:JXzH8nQsPlswgeRAPE3MuO9GYsAcnJvJ4vnMwN/5qkY=
-golang.org/x/exp v0.0.0-20260709172345-9ea1abe57597 h1:qLvzZeaANDgyVOA8pyHCOStGlXn0rseXma+GQjeuv2g=
-golang.org/x/exp v0.0.0-20260709172345-9ea1abe57597/go.mod h1:EdfpwwqSu+0Li0mzskwHU6FWDV3t9Q+RZDo3QMUtL3Q=
+golang.org/x/exp v0.0.0-20260718201538-764159d718ef h1:LkZ48HFgy/TvhTI0bcWkjgFkgLyKUwcTbDjS0DUjw+A=
+golang.org/x/exp v0.0.0-20260718201538-764159d718ef/go.mod h1:EdfpwwqSu+0Li0mzskwHU6FWDV3t9Q+RZDo3QMUtL3Q=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
@@ -867,8 +867,8 @@ google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyac
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.33.2/go.mod h1:JMHMWHQWaTccqQQlmk3MJZS+GWXOdAesneDmEnv2fbc=
-google.golang.org/grpc v1.82.0 h1:vguDnZUPjE26w09A63VoxZPnvPjB5Riyc0mkXPFmAIU=
-google.golang.org/grpc v1.82.0/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
+google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
+google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/resources/views/broadcast.html
+++ b/resources/views/broadcast.html
@@ -4,40 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Broadcasting Test</title>
-    <style>
-        * { box-sizing: border-box; margin: 0; padding: 0; }
-        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0f172a; color: #e2e8f0; min-height: 100vh; padding: 24px; }
-        h1 { font-size: 24px; margin-bottom: 8px; }
-        .subtitle { color: #94a3b8; margin-bottom: 24px; font-size: 14px; }
-        .controls { display: flex; gap: 12px; flex-wrap: wrap; margin-bottom: 24px; align-items: center; }
-        button { padding: 8px 16px; border: none; border-radius: 6px; cursor: pointer; font-size: 13px; font-weight: 500; }
-        .btn-connect { background: #2563eb; color: #fff; }
-        .btn-connect:hover { background: #1d4ed8; }
-        .btn-disconnect { background: #dc2626; color: #fff; }
-        .btn-disconnect:hover { background: #b91c1c; }
-        .btn-subscribe { background: #16a34a; color: #fff; }
-        .btn-subscribe:hover { background: #15803d; }
-        .btn-dispatch { background: #9333ea; color: #fff; }
-        .btn-dispatch:hover { background: #7e22ce; }
-        .status { display: flex; gap: 8px; align-items: center; margin-bottom: 20px; font-size: 13px; }
-        .status-dot { width: 10px; height: 10px; border-radius: 50%; }
-        .status-dot.disconnected { background: #dc2626; }
-        .status-dot.connected { background: #16a34a; }
-        .event-log { background: #1e293b; border-radius: 8px; padding: 16px; max-height: 500px; overflow-y: auto; font-family: 'SF Mono', 'Fira Code', monospace; font-size: 12px; }
-        .event-item { padding: 8px 0; border-bottom: 1px solid #334155; }
-        .event-item:last-child { border-bottom: none; }
-        .event-time { color: #64748b; margin-right: 8px; }
-        .event-name { color: #38bdf8; font-weight: 600; }
-        .event-channel { color: #a78bfa; }
-        .event-data { color: #94a3b8; white-space: pre-wrap; word-break: break-all; margin-top: 4px; }
-        .input-group { display: flex; gap: 8px; align-items: center; }
-        input { padding: 8px 12px; border: 1px solid #334155; border-radius: 6px; background: #1e293b; color: #e2e8f0; font-size: 13px; outline: none; }
-        input:focus { border-color: #2563eb; }
-        label { font-size: 13px; color: #94a3b8; }
-        .empty { color: #64748b; font-style: italic; }
-        .clear-btn { background: transparent; color: #94a3b8; border: 1px solid #334155; }
-        .clear-btn:hover { background: #1e293b; }
-    </style>
+    <link rel="stylesheet" href="/css/broadcast.css" />
 </head>
 <body>
     <h1>Broadcasting Test</h1>
@@ -125,6 +92,14 @@
         <div class="input-group">
             <label>Delay (s)</label>
             <input id="dispatchDelay" type="number" value="" style="width:120px" />
+        </div>
+        <div class="input-group">
+            <label>Tries</label>
+            <input id="dispatchTries" type="number" value="" style="width:60px" />
+        </div>
+        <div class="input-group">
+            <label>Backoff (s, csv)</label>
+            <input id="dispatchBackoff" placeholder="1,2" style="width:120px" />
         </div>
     </div>
 
@@ -364,6 +339,24 @@
                     setIf('dispatchQueueName', 'queue_name');
                     setInt('dispatchTimeout', 'timeout');
                     setInt('dispatchDelay', 'delay');
+                    // tries/backoff only take effect on the queued (private) path:
+                    // dispatchPublic forces broadcast_now=true and dispatchPresence
+                    // uses TeamPresenceBroadcast — both ignore them.
+                    if (type === 'private') {
+                        setInt('dispatchTries', 'tries');
+                        var backoff = val('dispatchBackoff');
+                        if (backoff) {
+                            var backoffArr = backoff.split(',').map(function (s) {
+                                return s.trim();
+                            }).filter(function (s) {
+                                return s !== ''; // empty slots ("1,,2") are omitted, not 0s
+                            }).map(function (s) {
+                                var n = Number(s); // Number("0.5") = 0.5, fractional seconds kept
+                                return isFinite(n) ? n : NaN; // non-numeric garbage omitted
+                            }).filter(function (n) { return isFinite(n); });
+                            if (backoffArr.length > 0) payload.backoff = backoffArr;
+                        }
+                    }
                     var conns = val('dispatchConns');
                     if (conns) payload.conns = conns.split(',').map(function(s){return s.trim()});
                 }
@@ -371,8 +364,6 @@
                 logStatus('Invalid JSON data: ' + e.message);
                 return;
             }
-
-            console.log('Dispatch payload:', payload);
 
             try {
                 var resp = await fetch(apiBase() + '/broadcasting/dispatch', {

--- a/resources/views/broadcast.html
+++ b/resources/views/broadcast.html
@@ -331,30 +331,28 @@
                 } else {
                     payload.order_data = data;
                     payload.should_fire = document.getElementById('dispatchShouldFire').checked;
-                    setIf('dispatchQueueConn', 'queue_conn');
-                    setIf('dispatchQueueName', 'queue_name');
-                    setInt('dispatchTimeout', 'timeout');
-                    setInt('dispatchDelay', 'delay');
-                    // tries/backoff only take effect on the queued private path: dispatchPublic
-                    // and dispatchPresence don't forward them, and sync broadcasts never retry.
-                    if (type === 'private') {
-                        setInt('dispatchTries', 'tries');
-                        var backoff = val('dispatchBackoff');
-                        if (backoff) {
-                            var backoffArr = backoff.split(',').map(function (s) {
-                                return s.trim();
-                            }).filter(function (s) {
-                                return s !== ''; // empty slots ("1,,2") are omitted, not 0s
-                            }).map(function (s) {
-                                var n = Number(s); // Number("0.5") = 0.5, fractional seconds kept
-                                return isFinite(n) ? n : NaN; // non-numeric garbage omitted
-                            }).filter(function (n) { return isFinite(n); });
-                            if (backoffArr.length > 0) payload.backoff = backoffArr;
-                        }
-                    }
-                    var conns = val('dispatchConns');
-                    if (conns) payload.conns = conns.split(',').map(function(s){return s.trim()});
                 }
+                // queue options (incl. tries/backoff) apply to all channel types
+                // on the queued path; sync broadcasts never retry.
+                setIf('dispatchQueueConn', 'queue_conn');
+                setIf('dispatchQueueName', 'queue_name');
+                setInt('dispatchTimeout', 'timeout');
+                setInt('dispatchDelay', 'delay');
+                setInt('dispatchTries', 'tries');
+                var backoff = val('dispatchBackoff');
+                if (backoff) {
+                    var backoffArr = backoff.split(',').map(function (s) {
+                        return s.trim();
+                    }).filter(function (s) {
+                        return s !== ''; // empty slots ("1,,2") are omitted, not 0s
+                    }).map(function (s) {
+                        var n = Number(s); // Number("0.5") = 0.5, fractional seconds kept
+                        return isFinite(n) ? n : NaN; // non-numeric garbage omitted
+                    }).filter(function (n) { return isFinite(n); });
+                    if (backoffArr.length > 0) payload.backoff = backoffArr;
+                }
+                var conns = val('dispatchConns');
+                if (conns) payload.conns = conns.split(',').map(function(s){return s.trim()});
             } catch (e) {
                 logStatus('Invalid JSON data: ' + e.message);
                 return;

--- a/resources/views/broadcast.html
+++ b/resources/views/broadcast.html
@@ -318,6 +318,7 @@
             var type = channelTypeFromName(name);
             var dataStr = document.getElementById('dispatchData').value;
             var payload = { channel_type: type, channel: name };
+            payload.broadcast_now = document.getElementById('dispatchBroadcastNow').checked;
 
             function val(id) { var el = document.getElementById(id); return el && el.value ? el.value : ''; }
             function setIf(id, key) { var v = val(id); if (v) payload[key] = v; }
@@ -330,18 +331,12 @@
                 } else {
                     payload.order_data = data;
                     payload.should_fire = document.getElementById('dispatchShouldFire').checked;
-                    if (type === 'public') {
-                        payload.broadcast_now = true;
-                    } else {
-                        payload.broadcast_now = document.getElementById('dispatchBroadcastNow').checked;
-                    }
                     setIf('dispatchQueueConn', 'queue_conn');
                     setIf('dispatchQueueName', 'queue_name');
                     setInt('dispatchTimeout', 'timeout');
                     setInt('dispatchDelay', 'delay');
-                    // tries/backoff only take effect on the queued (private) path:
-                    // dispatchPublic forces broadcast_now=true and dispatchPresence
-                    // uses TeamPresenceBroadcast — both ignore them.
+                    // tries/backoff only take effect on the queued private path: dispatchPublic
+                    // and dispatchPresence don't forward them, and sync broadcasts never retry.
                     if (type === 'private') {
                         setInt('dispatchTries', 'tries');
                         var backoff = val('dispatchBackoff');

--- a/resources/views/css/broadcast.css
+++ b/resources/views/css/broadcast.css
@@ -1,0 +1,32 @@
+* { box-sizing: border-box; margin: 0; padding: 0; }
+body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0f172a; color: #e2e8f0; min-height: 100vh; padding: 24px; }
+h1 { font-size: 24px; margin-bottom: 8px; }
+.subtitle { color: #94a3b8; margin-bottom: 24px; font-size: 14px; }
+.controls { display: flex; gap: 12px; flex-wrap: wrap; margin-bottom: 24px; align-items: center; }
+button { padding: 8px 16px; border: none; border-radius: 6px; cursor: pointer; font-size: 13px; font-weight: 500; }
+.btn-connect { background: #2563eb; color: #fff; }
+.btn-connect:hover { background: #1d4ed8; }
+.btn-disconnect { background: #dc2626; color: #fff; }
+.btn-disconnect:hover { background: #b91c1c; }
+.btn-subscribe { background: #16a34a; color: #fff; }
+.btn-subscribe:hover { background: #15803d; }
+.btn-dispatch { background: #9333ea; color: #fff; }
+.btn-dispatch:hover { background: #7e22ce; }
+.status { display: flex; gap: 8px; align-items: center; margin-bottom: 20px; font-size: 13px; }
+.status-dot { width: 10px; height: 10px; border-radius: 50%; }
+.status-dot.disconnected { background: #dc2626; }
+.status-dot.connected { background: #16a34a; }
+.event-log { background: #1e293b; border-radius: 8px; padding: 16px; max-height: 500px; overflow-y: auto; font-family: 'SF Mono', 'Fira Code', monospace; font-size: 12px; }
+.event-item { padding: 8px 0; border-bottom: 1px solid #334155; }
+.event-item:last-child { border-bottom: none; }
+.event-time { color: #64748b; margin-right: 8px; }
+.event-name { color: #38bdf8; font-weight: 600; }
+.event-channel { color: #a78bfa; }
+.event-data { color: #94a3b8; white-space: pre-wrap; word-break: break-all; margin-top: 4px; }
+.input-group { display: flex; gap: 8px; align-items: center; }
+input { padding: 8px 12px; border: 1px solid #334155; border-radius: 6px; background: #1e293b; color: #e2e8f0; font-size: 13px; outline: none; }
+input:focus { border-color: #2563eb; }
+label { font-size: 13px; color: #94a3b8; }
+.empty { color: #64748b; font-style: italic; }
+.clear-btn { background: transparent; color: #94a3b8; border: 1px solid #334155; }
+.clear-btn:hover { background: #1e293b; }

--- a/resources/views/echo.html
+++ b/resources/views/echo.html
@@ -6,40 +6,7 @@
     <title>Broadcasting Test — Laravel Echo</title>
     <script src="https://cdn.jsdelivr.net/npm/pusher-js@8.4.0/dist/web/pusher.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/laravel-echo@1.16.1/dist/echo.iife.js"></script>
-    <style>
-        * { box-sizing: border-box; margin: 0; padding: 0; }
-        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0f172a; color: #e2e8f0; min-height: 100vh; padding: 24px; }
-        h1 { font-size: 24px; margin-bottom: 8px; }
-        .subtitle { color: #94a3b8; margin-bottom: 24px; font-size: 14px; }
-        .controls { display: flex; gap: 12px; flex-wrap: wrap; margin-bottom: 24px; align-items: center; }
-        button { padding: 8px 16px; border: none; border-radius: 6px; cursor: pointer; font-size: 13px; font-weight: 500; }
-        .btn-connect { background: #2563eb; color: #fff; }
-        .btn-connect:hover { background: #1d4ed8; }
-        .btn-disconnect { background: #dc2626; color: #fff; }
-        .btn-disconnect:hover { background: #b91c1c; }
-        .btn-subscribe { background: #16a34a; color: #fff; }
-        .btn-subscribe:hover { background: #15803d; }
-        .btn-dispatch { background: #9333ea; color: #fff; }
-        .btn-dispatch:hover { background: #7e22ce; }
-        .status { display: flex; gap: 8px; align-items: center; margin-bottom: 20px; font-size: 13px; }
-        .status-dot { width: 10px; height: 10px; border-radius: 50%; }
-        .status-dot.disconnected { background: #dc2626; }
-        .status-dot.connected { background: #16a34a; }
-        .event-log { background: #1e293b; border-radius: 8px; padding: 16px; max-height: 500px; overflow-y: auto; font-family: 'SF Mono', 'Fira Code', monospace; font-size: 12px; }
-        .event-item { padding: 8px 0; border-bottom: 1px solid #334155; }
-        .event-item:last-child { border-bottom: none; }
-        .event-time { color: #64748b; margin-right: 8px; }
-        .event-name { color: #38bdf8; font-weight: 600; }
-        .event-channel { color: #a78bfa; }
-        .event-data { color: #94a3b8; white-space: pre-wrap; word-break: break-all; margin-top: 4px; }
-        .input-group { display: flex; gap: 8px; align-items: center; }
-        input { padding: 8px 12px; border: 1px solid #334155; border-radius: 6px; background: #1e293b; color: #e2e8f0; font-size: 13px; outline: none; }
-        input:focus { border-color: #2563eb; }
-        label { font-size: 13px; color: #94a3b8; }
-        .empty { color: #64748b; font-style: italic; }
-        .clear-btn { background: transparent; color: #94a3b8; border: 1px solid #334155; }
-        .clear-btn:hover { background: #1e293b; }
-    </style>
+    <link rel="stylesheet" href="/css/broadcast.css" />
 </head>
 <body>
     <h1>Broadcasting Test — Laravel Echo</h1>
@@ -127,6 +94,14 @@
         <div class="input-group">
             <label>Delay (s)</label>
             <input id="dispatchDelay" type="number" value="" style="width:120px" />
+        </div>
+        <div class="input-group">
+            <label>Tries</label>
+            <input id="dispatchTries" type="number" value="" style="width:60px" />
+        </div>
+        <div class="input-group">
+            <label>Backoff (s, csv)</label>
+            <input id="dispatchBackoff" placeholder="1,2" style="width:120px" />
         </div>
     </div>
 
@@ -295,9 +270,7 @@
                 var bare = stripPrefix(name, 'private-');
                 echoClient.private(bare)
                     .listen('.order.shipped', function (e) {
-                        console.log('Private channel event:', e);
                         logEvent('order.shipped', name, e);
-                        console.log('Private channel event logged');
                     });
                 logStatus('Subscribing to private channel ' + name + '...');
             } else {
@@ -359,6 +332,24 @@
                     setIf('dispatchQueueName', 'queue_name');
                     setInt('dispatchTimeout', 'timeout');
                     setInt('dispatchDelay', 'delay');
+                    // tries/backoff only take effect on the queued (private) path:
+                    // dispatchPublic forces broadcast_now=true and dispatchPresence
+                    // uses TeamPresenceBroadcast — both ignore them.
+                    if (type === 'private') {
+                        setInt('dispatchTries', 'tries');
+                        var backoff = val('dispatchBackoff');
+                        if (backoff) {
+                            var backoffArr = backoff.split(',').map(function (s) {
+                                return s.trim();
+                            }).filter(function (s) {
+                                return s !== ''; // empty slots ("1,,2") are omitted, not 0s
+                            }).map(function (s) {
+                                var n = Number(s); // Number("0.5") = 0.5, fractional seconds kept
+                                return isFinite(n) ? n : NaN; // non-numeric garbage omitted
+                            }).filter(function (n) { return isFinite(n); });
+                            if (backoffArr.length > 0) payload.backoff = backoffArr;
+                        }
+                    }
                     var conns = val('dispatchConns');
                     if (conns) payload.conns = conns.split(',').map(function(s){return s.trim()});
                 }
@@ -366,8 +357,6 @@
                 logStatus('Invalid JSON data: ' + e.message);
                 return;
             }
-
-            console.log('Dispatch payload:', payload);
 
             try {
                 var resp = await fetch(apiBase() + '/broadcasting/dispatch', {
@@ -378,7 +367,6 @@
                 var result = await resp.json();
                 if (resp.ok) {
                     logStatus('Dispatched: ' + result.message + ' → ' + result.channel);
-                    // logEvent('Dispatched', result.channel || (type + '-' + name), data);
                 } else {
                     logStatus('Dispatch failed (' + resp.status + '): ' + (result.error || JSON.stringify(result)));
                 }

--- a/resources/views/echo.html
+++ b/resources/views/echo.html
@@ -324,30 +324,28 @@
                 } else {
                     payload.order_data = data;
                     payload.should_fire = document.getElementById('dispatchShouldFire').checked;
-                    setIf('dispatchQueueConn', 'queue_conn');
-                    setIf('dispatchQueueName', 'queue_name');
-                    setInt('dispatchTimeout', 'timeout');
-                    setInt('dispatchDelay', 'delay');
-                    // tries/backoff only take effect on the queued private path: dispatchPublic
-                    // and dispatchPresence don't forward them, and sync broadcasts never retry.
-                    if (type === 'private') {
-                        setInt('dispatchTries', 'tries');
-                        var backoff = val('dispatchBackoff');
-                        if (backoff) {
-                            var backoffArr = backoff.split(',').map(function (s) {
-                                return s.trim();
-                            }).filter(function (s) {
-                                return s !== ''; // empty slots ("1,,2") are omitted, not 0s
-                            }).map(function (s) {
-                                var n = Number(s); // Number("0.5") = 0.5, fractional seconds kept
-                                return isFinite(n) ? n : NaN; // non-numeric garbage omitted
-                            }).filter(function (n) { return isFinite(n); });
-                            if (backoffArr.length > 0) payload.backoff = backoffArr;
-                        }
-                    }
-                    var conns = val('dispatchConns');
-                    if (conns) payload.conns = conns.split(',').map(function(s){return s.trim()});
                 }
+                // queue options (incl. tries/backoff) apply to all channel types
+                // on the queued path; sync broadcasts never retry.
+                setIf('dispatchQueueConn', 'queue_conn');
+                setIf('dispatchQueueName', 'queue_name');
+                setInt('dispatchTimeout', 'timeout');
+                setInt('dispatchDelay', 'delay');
+                setInt('dispatchTries', 'tries');
+                var backoff = val('dispatchBackoff');
+                if (backoff) {
+                    var backoffArr = backoff.split(',').map(function (s) {
+                        return s.trim();
+                    }).filter(function (s) {
+                        return s !== ''; // empty slots ("1,,2") are omitted, not 0s
+                    }).map(function (s) {
+                        var n = Number(s); // Number("0.5") = 0.5, fractional seconds kept
+                        return isFinite(n) ? n : NaN; // non-numeric garbage omitted
+                    }).filter(function (n) { return isFinite(n); });
+                    if (backoffArr.length > 0) payload.backoff = backoffArr;
+                }
+                var conns = val('dispatchConns');
+                if (conns) payload.conns = conns.split(',').map(function(s){return s.trim()});
             } catch (e) {
                 logStatus('Invalid JSON data: ' + e.message);
                 return;

--- a/resources/views/echo.html
+++ b/resources/views/echo.html
@@ -311,6 +311,7 @@
             var type = channelTypeFromName(name);
             var dataStr = document.getElementById('dispatchData').value;
             var payload = { channel_type: type, channel: name };
+            payload.broadcast_now = document.getElementById('dispatchBroadcastNow').checked;
 
             function val(id) { var el = document.getElementById(id); return el && el.value ? el.value : ''; }
             function setIf(id, key) { var v = val(id); if (v) payload[key] = v; }
@@ -323,18 +324,12 @@
                 } else {
                     payload.order_data = data;
                     payload.should_fire = document.getElementById('dispatchShouldFire').checked;
-                    if (type === 'public') {
-                        payload.broadcast_now = true;
-                    } else {
-                        payload.broadcast_now = document.getElementById('dispatchBroadcastNow').checked;
-                    }
                     setIf('dispatchQueueConn', 'queue_conn');
                     setIf('dispatchQueueName', 'queue_name');
                     setInt('dispatchTimeout', 'timeout');
                     setInt('dispatchDelay', 'delay');
-                    // tries/backoff only take effect on the queued (private) path:
-                    // dispatchPublic forces broadcast_now=true and dispatchPresence
-                    // uses TeamPresenceBroadcast — both ignore them.
+                    // tries/backoff only take effect on the queued private path: dispatchPublic
+                    // and dispatchPresence don't forward them, and sync broadcasts never retry.
                     if (type === 'private') {
                         setInt('dispatchTries', 'tries');
                         var backoff = val('dispatchBackoff');

--- a/tests/feature/broadcast_test.go
+++ b/tests/feature/broadcast_test.go
@@ -1117,6 +1117,122 @@ func (s *BroadcastTestSuite) TestDispatch_BackoffWithoutTries_Suppressed() {
 	s.NotContains(jobs[0].Payload, `"backoff"`, "backoff must not serialize without tries")
 }
 
+func (s *BroadcastTestSuite) TestDispatchViaHTTP_Public_WithQueueOptions() {
+	scope, err := tests.OverrideConfig(map[string]any{"queue.default": "database"})
+	s.Require().NoError(err)
+	defer func() { s.NoError(scope.Restore()) }()
+
+	body, err := supporthttp.NewBody().
+		SetField("channel_type", "public").
+		SetField("channel", "public-http-orders").
+		SetField("order_data", map[string]any{"id": 1, "name": "Public HTTP Broadcast"}).
+		SetField("should_fire", true).
+		SetField("queue_name", "public-http-queue").
+		SetField("delay", 1).
+		SetField("tries", 3).
+		SetField("backoff", []float64{1, 2}).
+		Build()
+	s.Require().NoError(err)
+
+	resp, err := s.Http(s.T()).
+		WithHeader("Content-Type", body.ContentType()).
+		Post("/broadcasting/dispatch", body.Reader())
+	s.NoError(err)
+	resp.AssertOk()
+
+	// dispatchPublic must forward queue options: the job lands in the named
+	// queue, the payload serializes tries/backoff (ms), and the delay is
+	// converted seconds → available_at (future).
+	var jobs []frameworkmodels.Job
+	s.NoError(facades.DB().Table("jobs").Where("queue", "public-http-queue").Get(&jobs))
+	s.Require().Len(jobs, 1)
+	s.Equal("public-http-queue", jobs[0].Queue)
+	s.Require().NotNil(jobs[0].AvailableAt)
+	s.Greater(jobs[0].AvailableAt.StdTime(), time.Now())
+	var payload struct {
+		Args []struct {
+			Value string `json:"value"`
+		} `json:"args"`
+	}
+	s.NoError(json.Unmarshal([]byte(jobs[0].Payload), &payload))
+	s.Require().Len(payload.Args, 1)
+	var item struct {
+		Tries   int     `json:"tries"`
+		Backoff []int64 `json:"backoff"`
+	}
+	s.NoError(json.Unmarshal([]byte(payload.Args[0].Value), &item))
+	s.Equal(3, item.Tries)
+	s.Equal([]int64{1000, 2000}, item.Backoff) // backoff 1s/2s → ms
+}
+
+func (s *BroadcastTestSuite) TestDispatchViaHTTP_Public_ShouldFireFalse_SkipsDispatch() {
+	scope, err := tests.OverrideConfig(map[string]any{"queue.default": "database"})
+	s.Require().NoError(err)
+	defer func() { s.NoError(scope.Restore()) }()
+
+	body, err := supporthttp.NewBody().
+		SetField("channel_type", "public").
+		SetField("channel", "public-http-skip").
+		SetField("order_data", map[string]any{"id": 2, "name": "Public HTTP Skip"}).
+		SetField("should_fire", false).
+		SetField("queue_name", "public-http-skip-queue").
+		SetField("tries", 3).
+		Build()
+	s.Require().NoError(err)
+
+	resp, err := s.Http(s.T()).
+		WithHeader("Content-Type", body.ContentType()).
+		Post("/broadcasting/dispatch", body.Reader())
+	s.NoError(err)
+	resp.AssertOk()
+
+	// dispatchPublic must honor should_fire (not hardcode true): with
+	// should_fire=false nothing is queued, even though queue options are set.
+	count, err := facades.DB().Table("jobs").Where("queue", "public-http-skip-queue").Count()
+	s.NoError(err)
+	s.Equal(int64(0), count, "no job should be queued when should_fire is false")
+}
+
+func (s *BroadcastTestSuite) TestDispatchViaHTTP_Presence_WithQueueOptions() {
+	scope, err := tests.OverrideConfig(map[string]any{"queue.default": "database"})
+	s.Require().NoError(err)
+	defer func() { s.NoError(scope.Restore()) }()
+
+	body, err := supporthttp.NewBody().
+		SetField("channel_type", "presence").
+		SetField("channel", "presence-team.http").
+		SetField("team_data", map[string]any{"id": 1, "name": "Presence HTTP Broadcast"}).
+		SetField("queue_name", "presence-http-queue").
+		SetField("tries", 3).
+		Build()
+	s.Require().NoError(err)
+
+	resp, err := s.Http(s.T()).
+		WithHeader("Content-Type", body.ContentType()).
+		Post("/broadcasting/dispatch", body.Reader())
+	s.NoError(err)
+	resp.AssertOk()
+
+	// dispatchPresence must forward queue options: the job lands in the named
+	// queue and the payload serializes the retry policy.
+	var jobs []frameworkmodels.Job
+	s.NoError(facades.DB().Table("jobs").Where("queue", "presence-http-queue").Get(&jobs))
+	s.Require().Len(jobs, 1)
+	s.Equal("presence-http-queue", jobs[0].Queue)
+	var payload struct {
+		Args []struct {
+			Value string `json:"value"`
+		} `json:"args"`
+	}
+	s.NoError(json.Unmarshal([]byte(jobs[0].Payload), &payload))
+	s.Require().Len(payload.Args, 1)
+	var item struct {
+		Tries int `json:"tries"`
+	}
+	s.NoError(json.Unmarshal([]byte(payload.Args[0].Value), &item))
+	s.Equal(3, item.Tries)
+}
+
 // countBroadcastEvents returns the number of "Broadcasting event" log entries
 // that carry the given OrderData marker. Each entry corresponds to exactly one
 // broadcast attempt by the log driver. Counting only entries that contain the

--- a/tests/feature/broadcast_test.go
+++ b/tests/feature/broadcast_test.go
@@ -977,6 +977,211 @@ func (s *BroadcastTestSuite) TestDispatch_WithConnections() {
 	s.Contains(logText, "Connections Order", "expected log driver to record the broadcast payload")
 }
 
+func (s *BroadcastTestSuite) TestDispatch_WithTriesAndBackoff() {
+	scope, err := tests.OverrideConfig(map[string]any{"queue.default": "database"})
+	s.Require().NoError(err)
+	defer func() { s.NoError(scope.Restore()) }()
+
+	s.NoError(facades.Broadcast().Dispatch(context.Background(), &events.OrderShippedBroadcast{
+		ChannelType: "public",
+		ChannelName: "retry-orders",
+		ShouldFire:  true,
+		// "broken" is intentionally NOT in config/broadcasting.go: broadcastToConns
+		// iterates conns in order, so the "log" driver emits its per-attempt line
+		// first, then cfg.Connection("broken") returns connection-not-found and the
+		// attempt fails. "log" must stay first; adding a "broken" connection to the
+		// config would silently change this test's behavior.
+		Conns:     []string{"log", "broken"},
+		Tries:     3,
+		Backoff:   []time.Duration{100 * time.Millisecond, 200 * time.Millisecond},
+		OrderData: map[string]any{"id": 1, "name": "Retryable Broadcast"},
+	}))
+
+	// Dispatch-time capture: queued payload carries tries/backoff (ms).
+	var jobs []frameworkmodels.Job
+	s.NoError(facades.DB().Table("jobs").Where("queue", "default").Get(&jobs))
+	s.Require().Len(jobs, 1)
+	var payload struct {
+		Args []struct {
+			Value string `json:"value"`
+		} `json:"args"`
+	}
+	s.NoError(json.Unmarshal([]byte(jobs[0].Payload), &payload))
+	s.Require().Len(payload.Args, 1)
+	var item struct {
+		Tries   int     `json:"tries"`
+		Backoff []int64 `json:"backoff"`
+	}
+	s.NoError(json.Unmarshal([]byte(payload.Args[0].Value), &item))
+	s.Equal(3, item.Tries)
+	s.Equal([]int64{100, 200}, item.Backoff)
+
+	before := s.countBroadcastEvents("Retryable Broadcast")
+	worker := facades.Queue().Worker(contractsqueue.Args{
+		Connection: "database",
+		Queue:      "default",
+		Concurrent: 1,
+		Tries:      1, // event policy must override the worker's tries
+	})
+	workerErr := make(chan error, 1)
+	start := time.Now()
+	go func() { workerErr <- worker.Run() }()
+
+	// The queued broadcast always FAILS (the "broken" connection), so the
+	// completion signal is the failed job landing in the failer. Poll with a
+	// bounded timeout instead of a fixed sleep so a slow worker can't strand
+	// the job or mask a startup failure.
+	elapsed, ok := s.waitForFailedBroadcast(start, 5*time.Second)
+	_ = worker.Shutdown()
+	s.Require().True(ok, "expected goravel_broadcast job to fail within 5s")
+	s.NoError(<-workerErr, "worker should start and stop cleanly")
+
+	// The worker pops the job from the jobs table before retries run in-process,
+	// so jobs==0 alone is not a timing signal — keep it as a separate check.
+	count, err := facades.DB().Table("jobs").Count()
+	s.NoError(err)
+	s.Equal(int64(0), count, "job should be consumed")
+
+	// Without the 100ms+200ms backoff sleeps this would be ~0 and FAIL; the
+	// upper bound catches pathological slowness.
+	s.GreaterOrEqual(elapsed, 300*time.Millisecond, "100ms + 200ms backoff should have slept before the final attempt")
+	s.Less(elapsed, 3*time.Second, "retries should complete quickly")
+	s.Equal(before+3, s.countBroadcastEvents("Retryable Broadcast"),
+		"event BroadcastTries=3 should override worker Tries=1")
+}
+
+func (s *BroadcastTestSuite) TestDispatch_WithoutTries_SingleShot() {
+	scope, err := tests.OverrideConfig(map[string]any{"queue.default": "database"})
+	s.Require().NoError(err)
+	defer func() { s.NoError(scope.Restore()) }()
+
+	s.NoError(facades.Broadcast().Dispatch(context.Background(), &events.OrderShippedBroadcast{
+		ChannelType: "public",
+		ChannelName: "single-shot-orders",
+		ShouldFire:  true,
+		// Same phantom-connection mechanism as TestDispatch_WithTriesAndBackoff:
+		// "log" emits its line first, then the unconfigured "broken" connection
+		// fails the attempt (broadcastToConns short-circuits on the first error).
+		Conns:     []string{"log", "broken"},
+		OrderData: map[string]any{"id": 2, "name": "Single Shot Broadcast"},
+	}))
+
+	var jobs []frameworkmodels.Job
+	s.NoError(facades.DB().Table("jobs").Where("queue", "default").Get(&jobs))
+	s.Require().Len(jobs, 1)
+	s.NotContains(jobs[0].Payload, `"tries"`) // omitempty: no retry policy serialized
+	s.NotContains(jobs[0].Payload, `"backoff"`)
+
+	before := s.countBroadcastEvents("Single Shot Broadcast")
+	worker := facades.Queue().Worker(contractsqueue.Args{
+		Connection: "database",
+		Queue:      "default",
+		Concurrent: 1,
+		Tries:      3, // worker would retry, but the event stays single-shot
+	})
+	workerErr := make(chan error, 1)
+	start := time.Now()
+	go func() { workerErr <- worker.Run() }()
+
+	// Same completion signal as the retry test: the failed job landing in the
+	// failer, polled with a bounded timeout instead of a fixed sleep.
+	_, ok := s.waitForFailedBroadcast(start, 5*time.Second)
+	_ = worker.Shutdown()
+	s.Require().True(ok, "expected goravel_broadcast job to fail within 5s")
+	s.NoError(<-workerErr, "worker should start and stop cleanly")
+
+	count, err := facades.DB().Table("jobs").Count()
+	s.NoError(err)
+	s.Equal(int64(0), count)
+	s.Equal(before+1, s.countBroadcastEvents("Single Shot Broadcast"),
+		"broadcast without BroadcastTries must fail after a single attempt despite worker Tries=3")
+}
+
+func (s *BroadcastTestSuite) TestDispatch_BackoffWithoutTries_Suppressed() {
+	scope, err := tests.OverrideConfig(map[string]any{"queue.default": "database"})
+	s.Require().NoError(err)
+	defer func() { s.NoError(scope.Restore()) }()
+
+	s.NoError(facades.Broadcast().Dispatch(context.Background(), &events.OrderShippedBroadcast{
+		ChannelType: "public",
+		ChannelName: "backoff-only-orders",
+		ShouldFire:  true,
+		Conns:       []string{"null"},
+		Backoff:     []time.Duration{time.Second}, // no BroadcastTries → ignored
+		OrderData:   map[string]any{"id": 3},
+	}))
+
+	var jobs []frameworkmodels.Job
+	s.NoError(facades.DB().Table("jobs").Where("queue", "default").Get(&jobs))
+	s.Require().Len(jobs, 1)
+	s.NotContains(jobs[0].Payload, `"backoff"`, "backoff must not serialize without tries")
+}
+
+// countBroadcastEvents returns the number of "Broadcasting event" log entries
+// that carry the given OrderData marker. Each entry corresponds to exactly one
+// broadcast attempt by the log driver. Counting only entries that contain the
+// marker keeps the count immune to (a) SQL log lines that embed the same
+// marker via the queued/failed payload, and (b) accumulation across test runs
+// when combined with a before/after delta.
+//
+// Formatter coupling: the matcher relies on the "single" channel's JSON
+// formatter putting `"message":"Broadcasting event"` and the payload on one
+// line. The "daily" text channel splits the payload onto its own `[With]`
+// line, so those entries are naturally excluded. If config/logging.go ever
+// switches "single" to a non-JSON formatter (or "daily" to JSON), the count
+// will silently drift — the first symptom is `before+3`/`before+1` failing.
+func (s *BroadcastTestSuite) countBroadcastEvents(marker string) int {
+	matches, err := filepath.Glob("../../storage/logs/*.log")
+	s.Require().NoError(err)
+	count := 0
+	for _, m := range matches {
+		if b, rErr := os.ReadFile(m); rErr == nil {
+			for _, line := range strings.Split(string(b), "\n") {
+				// Tighten to the JSON formatter's line shape so a formatter
+				// change fails loudly instead of double-counting (daily→json).
+				if strings.Contains(line, `"message":"Broadcasting event"`) && strings.Contains(line, marker) {
+					count++
+				}
+			}
+		}
+	}
+	return count
+}
+
+// waitForFailedBroadcast polls the queue failer until a failed goravel_broadcast
+// job appears (the queued broadcast always fails via the phantom "broken"
+// connection), returning the elapsed time since start. The failure is recorded
+// by the worker's failed-job processor after all in-process retries are
+// exhausted, so its appearance in the failer is the reliable completion signal —
+// unlike the jobs table, which the worker empties before retries run. Returns
+// ok=false if the timeout elapses.
+//
+// Invariants this relies on: (a) SetupTest's RefreshDatabase (migrate:refresh)
+// drops and recreates failed_jobs before every test, so the table starts empty;
+// and (b) each new test dispatches exactly one queued broadcast, so the first
+// failed goravel_broadcast row this helper sees is that job's. If a future test
+// stops calling RefreshDatabase or dispatches a second queued broadcast, the
+// poll would latch onto a stale/foreign row instead of timing out.
+func (s *BroadcastTestSuite) waitForFailedBroadcast(start time.Time, timeout time.Duration) (time.Duration, bool) {
+	deadline := time.Now().Add(timeout)
+	for {
+		failedJobs, err := facades.Queue().Failer().All()
+		if err != nil {
+			s.T().Logf("failed to list failed jobs: %v", err)
+		} else {
+			for _, fj := range failedJobs {
+				if fj.Signature() == "goravel_broadcast" {
+					return time.Since(start), true
+				}
+			}
+		}
+		if time.Now().After(deadline) {
+			return time.Since(start), false
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
 func soketiTrigger(channel, event string, data map[string]any) error {
 	return soketiTriggerMulti([]string{channel}, event, data)
 }


### PR DESCRIPTION
## Summary
- Queued broadcasts can declare a per-event retry policy: `BroadcastTries()` sets the max attempts and `BroadcastBackoff()` sets the delay before each retry, overriding the queue worker's global `tries`
- Public, private, and presence dispatch now accept the same queue options — queue name, queue connection, delay, timeout, tries/backoff — wired through the demo pages and forwarded to the dispatched event
- `dispatchPublic` now honors `should_fire` instead of always dispatching, and feature tests pin queue-option forwarding for public/presence channels plus the `should_fire=false` skip path

## Why
This example PR covers goravel/framework#1529, which lets each queued broadcast event opt into its own queue policy instead of inheriting the queue worker's globals. `TeamPresenceBroadcast` now implements all seven optional broadcast interfaces (`BroadcastQueue`, `BroadcastConnections`, `BroadcastQueueConnection`, `BroadcastDelay`, `BroadcastTimeout`, `BroadcastTries`, `BroadcastBackoff`), and the dispatch controller shares a single `queueOptions()` helper so public and presence dispatches forward the same options the private path already did. The demo pages no longer restrict tries/backoff to the private channel, so every channel type can be configured from the UI.

Previously `dispatchPublic` hardcoded `ShouldFire: true` and only the private path forwarded queue options, so public/presence broadcasts couldn't be skipped or tuned per event. `dispatchPublic` now honors `should_fire` (with a negative-path test asserting nothing is queued), and the feature tests assert dispatch-time serialization for the new forwarding:

```go
// app/http/controllers/broadcast_controller.go
// dispatchPublic now honors should_fire and forwards the same queue
// options as the private path.
err := facades.Broadcast().Dispatch(context.Background(), &events.OrderShippedBroadcast{
	ChannelType:        "public",
	OrderData:          req.OrderData,
	ShouldFire:         req.ShouldFire,
	QueueName:          req.QueueName,
	Conns:              req.Conns,
	QueueConn:          req.QueueConn,
	DelayedAt:          delayedAt,
	Timeout:            timeout,
	Tries:              tries,
	Backoff:            backoff,
	ShouldBroadcastNow: req.BroadcastNow,
	ChannelName:        req.Channel,
})
```

Note on dependencies: the framework is pinned to the PR-head pseudo-version `v1.18.1-0.20260802085640-2aa82fd133a7` (resolves `refs/pull/1529/head`), since per-event retry/backoff is only available on the unreleased framework PR head. This should be swapped for a tagged release once goravel/framework#1529 merges; it also brings transitive bumps (`grpc 1.82.1`, `mimetype 1.4.15`, `go-runewidth 0.0.27`, `golang.org/x/exp` pseudo-version).
