### PR TITLE
test: add make:event broadcast test cases (framework#1532)

### DIFF
--- a/app/events/broadcast.go
+++ b/app/events/broadcast.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/goravel/framework/broadcasting"
-	contracts "github.com/goravel/framework/contracts/broadcasting"
 )
 
 type OrderShippedBroadcast struct {
@@ -22,13 +21,13 @@ type OrderShippedBroadcast struct {
 	ChannelName        string
 }
 
-func (e *OrderShippedBroadcast) BroadcastOn() []contracts.Channel {
+func (e *OrderShippedBroadcast) BroadcastOn() []string {
 	if e.ChannelType == "public" {
-		return []contracts.Channel{
+		return []string{
 			broadcasting.PublicChannel(e.ChannelName),
 		}
 	}
-	return []contracts.Channel{
+	return []string{
 		broadcasting.PrivateChannel(e.ChannelName),
 	}
 }
@@ -79,7 +78,7 @@ func (e *OrderShippedBroadcast) BroadcastNow() bool {
 
 type EmptyBroadcastEvent struct{}
 
-func (e *EmptyBroadcastEvent) BroadcastOn() []contracts.Channel {
+func (e *EmptyBroadcastEvent) BroadcastOn() []string {
 	return nil
 }
 
@@ -108,8 +107,8 @@ type TeamPresenceBroadcast struct {
 	Backoff            []time.Duration
 }
 
-func (e *TeamPresenceBroadcast) BroadcastOn() []contracts.Channel {
-	return []contracts.Channel{
+func (e *TeamPresenceBroadcast) BroadcastOn() []string {
+	return []string{
 		broadcasting.PresenceChannel(e.ChannelName),
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/goravel/cos v1.18.0
 	github.com/goravel/example-proto v0.0.1
 	github.com/goravel/fiber v1.18.0
-	github.com/goravel/framework v1.18.1-0.20260804104356-c0b610b049d7
+	github.com/goravel/framework v1.18.1-0.20260805080351-d2e95f66f306
 	github.com/goravel/gemini v1.18.0
 	github.com/goravel/gin v1.18.0
 	github.com/goravel/minio v1.18.0
@@ -255,4 +255,5 @@ require (
 	gorm.io/gorm v1.31.2 // indirect
 	gorm.io/plugin/dbresolver v1.6.2 // indirect
 )
-replace github.com/goravel/framework => github.com/goravel/framework v1.18.1-0.20260804104356-c0b610b049d7
+
+replace github.com/goravel/framework => github.com/goravel/framework v1.18.1-0.20260805080351-d2e95f66f306

--- a/go.sum
+++ b/go.sum
@@ -296,8 +296,8 @@ github.com/goravel/example-proto v0.0.1 h1:ZxETeKREQWjuJ49bX/Hqj1NLR5Vyj489Ks6dR
 github.com/goravel/example-proto v0.0.1/go.mod h1:I8IPsHr4Ndf7KxmdsRpBR2LQ0Geo48+pjv9IIWf3mZg=
 github.com/goravel/fiber v1.18.0 h1:q9EACPCpEn+N5SX6yyI7hsdA1Zr2NFDJLdiAXQKKUw8=
 github.com/goravel/fiber v1.18.0/go.mod h1:swGaS9bq2wT6T6uthcHEJ2In6QyaTljsqrkRwk+wPfI=
-github.com/goravel/framework v1.18.1-0.20260804104356-c0b610b049d7 h1:v+I/2jykTh8wA5NjGh8k+/ZeSs1uSsph6mPsZoDlH90=
-github.com/goravel/framework v1.18.1-0.20260804104356-c0b610b049d7/go.mod h1:EZBVw/Le3hlnINJ619fanc7aDo5LEDM6YDrw+MmbNXA=
+github.com/goravel/framework v1.18.1-0.20260805080351-d2e95f66f306 h1:7asHFinzj97WSPP5jZHvq8IyMtWBdKUQXBj4lPBDokA=
+github.com/goravel/framework v1.18.1-0.20260805080351-d2e95f66f306/go.mod h1:EZBVw/Le3hlnINJ619fanc7aDo5LEDM6YDrw+MmbNXA=
 github.com/goravel/gemini v1.18.0 h1:Tv6IJ3KvBvH5QD7kAM3XFQR0g8IUfkqMbRGi7dtlWUo=
 github.com/goravel/gemini v1.18.0/go.mod h1:b4FueB0O0Qkz71eVWLiSaKghp+Eb/1hNNICkk7vMgrQ=
 github.com/goravel/gin v1.18.0 h1:4eIy9eAzH+0mz8SN03iwwocIGwc/2dpZkgz6Ol68KIE=

--- a/tests/feature/event_test.go
+++ b/tests/feature/event_test.go
@@ -246,6 +246,50 @@ func (s *EventTestSuite) TestCommandMakeEvent() {
 	s.True(file.Contains(nestedPath, "type "+nestedEventName+" struct {"))
 }
 
+func (s *EventTestSuite) TestCommandMakeEventBroadcast() {
+	eventName := s.uniqueName("EventBroadcast")
+	eventPath := path.App("events", str.Of(eventName).Snake().String()+".go")
+
+	s.NoError(os.RemoveAll(eventPath))
+	s.T().Cleanup(func() {
+		s.NoError(os.RemoveAll(eventPath))
+	})
+
+	s.NoError(facades.Artisan().Call("--no-ansi make:event --broadcast " + eventName))
+	s.True(file.Exists(eventPath))
+	s.True(file.Contains(eventPath, `"github.com/goravel/framework/contracts/broadcasting"`))
+	s.True(file.Contains(eventPath, "var _ broadcasting.ShouldBroadcast = (*"+eventName+")(nil)"))
+	s.True(file.Contains(eventPath, "func (receiver *"+eventName+") BroadcastOn() []string {"))
+	s.True(file.Contains(eventPath, "func (receiver *"+eventName+") BroadcastAs() string {"))
+	s.True(file.Contains(eventPath, "func (receiver *"+eventName+") BroadcastWith() map[string]any {"))
+	s.True(file.Contains(eventPath, "func (receiver *"+eventName+") BroadcastWhen() bool {"))
+	s.False(file.Contains(eventPath, `"github.com/goravel/framework/contracts/event"`))
+	s.False(file.Contains(eventPath, "Handle("))
+	s.False(file.Contains(eventPath, "BroadcastNow()"))
+}
+
+func (s *EventTestSuite) TestCommandMakeEventBroadcastNow() {
+	eventName := s.uniqueName("EventBroadcastNow")
+	eventPath := path.App("events", str.Of(eventName).Snake().String()+".go")
+
+	s.NoError(os.RemoveAll(eventPath))
+	s.T().Cleanup(func() {
+		s.NoError(os.RemoveAll(eventPath))
+	})
+
+	s.NoError(facades.Artisan().Call("--no-ansi make:event --broadcast --now " + eventName))
+	s.True(file.Exists(eventPath))
+	s.True(file.Contains(eventPath, `"github.com/goravel/framework/contracts/broadcasting"`))
+	s.True(file.Contains(eventPath, "var _ broadcasting.ShouldBroadcast = (*"+eventName+")(nil)"))
+	s.True(file.Contains(eventPath, "func (receiver *"+eventName+") BroadcastOn() []string {"))
+	s.True(file.Contains(eventPath, "func (receiver *"+eventName+") BroadcastAs() string {"))
+	s.True(file.Contains(eventPath, "func (receiver *"+eventName+") BroadcastWith() map[string]any {"))
+	s.True(file.Contains(eventPath, "func (receiver *"+eventName+") BroadcastWhen() bool {"))
+	s.True(file.Contains(eventPath, "func (receiver *"+eventName+") BroadcastNow() bool {\n\treturn true\n}"))
+	s.False(file.Contains(eventPath, `"github.com/goravel/framework/contracts/event"`))
+	s.False(file.Contains(eventPath, "Handle("))
+}
+
 func (s *EventTestSuite) TestCommandMakeListener() {
 	listenerName := s.uniqueName("ListenerFeature")
 	nestedPackage := s.uniqueName("ListenerFeatureNested")


### PR DESCRIPTION
## Summary
- `make:event --broadcast` now scaffolds a broadcasting event (implementing `BroadcastOn`, `BroadcastAs`, `BroadcastWith`, and `BroadcastWhen`), and `--broadcast --now` additionally scaffolds `BroadcastNow` returning `true`; both are covered by new feature tests.
- Broadcast event channels are declared as plain `[]string` instead of the removed `contracts.Channel` struct.
- Framework bumped to the `v1.18.1-0.20260805080351-d2e95f66f306` pseudo-version containing framework#1532 (`make:event` broadcast/now flags and the broadcasting channel refactor).

## Why
Framework PR goravel/framework#1532 adds `--broadcast` and `--broadcast --now` flags to the `make:event` command and replaces the `broadcasting.Channel` struct with plain `[]string` channels. The example repository must stay in sync with that API so the generated events compile and demonstrate the new scaffolding.

The example's broadcast events now return `[]string` channels, and the event feature suite gains coverage for both new command flags, verifying the scaffolded file contents (broadcast methods present, listener-only methods absent, and `BroadcastNow` returning `true` only for the `--now` variant).

```go
type OrderShippedBroadcast struct {
	OrderData   map[string]any
	ChannelName string
}

func (e *OrderShippedBroadcast) BroadcastOn() []string {
	return []string{
		broadcasting.PublicChannel(e.ChannelName),
	}
}
```
